### PR TITLE
Fix Base.vcat type piracy and Vector haskey to enable MPI runs

### DIFF
--- a/ext/OctofitterPigeonsExt/OctofitterPigeonsExt.jl
+++ b/ext/OctofitterPigeonsExt/OctofitterPigeonsExt.jl
@@ -14,7 +14,12 @@ function Pigeons.initialization(model::Octofitter.LogDensityModel, rng::Abstract
 
     Octofitter.get_starting_point!!(rng, model)
 
-    if isnothing(model.starting_points) || !haskey(model.starting_points, chain_no)
+    # `model.starting_points` is a `Vector` (see LogDensityModel), so validate the
+    # chain index with a bounds check. (Previously this used `haskey`, which is not
+    # defined for `Vector`/`Int` and only worked incidentally when some other loaded
+    # package provided it; under MPI the child process loads a minimal set of
+    # packages and `haskey(::Vector, ::Int)` is undefined.)
+    if isnothing(model.starting_points) || !checkbounds(Bool, model.starting_points, chain_no)
         @show model.starting_points chain_no
         error("Insufficient starting points provided. Provide at least one per chain. (model.starting_points is too short)")
     end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -318,7 +318,19 @@ end
 vars = vcat(vars1, vars2)
 ```
 """
-function Base.vcat(vars1::Tuple, vars2::Tuple, vars_rest::Tuple...)
+function Base.vcat(
+    vars1::Tuple{Priors,Derived,Vararg},
+    vars2::Tuple{Priors,Derived,Vararg},
+    vars_rest::Tuple{Priors,Derived,Vararg}...,
+)
+    # NOTE: dispatch is restricted to tuples whose first two elements are a
+    # `Priors` and a `Derived` (i.e. the output of the `@variables` macro). This
+    # avoids type-piracy on `Base.vcat(::Tuple, ...)`, which otherwise hijacks
+    # ordinary tuple `vcat`/matrix-literal calls in *other* packages (e.g. SIMD.jl's
+    # `const CAST_SIZE_CHANGE_FLOAT = [(:fptrunc, >); (:fpext, <)]`) and throws
+    # "First argument does not appear to be from @variables macro". That surfaces
+    # when those packages are loaded from source (e.g. Pigeons MPI child processes
+    # run with `--compiled-modules=no` on Julia < 1.11).
     # Check that these are actually @variables outputs
     # They should have at least Priors and Derived as first two elements
     if length(vars1) < 2 || !isa(vars1[1], Priors) || !isa(vars1[2], Derived)
@@ -429,5 +441,6 @@ function _vcat_two_variables(vars1::Tuple, vars2::Tuple)
     end
 end
 
-# Also support concatenating more than 2 blocks at once using varargs
-Base.vcat(vars::Tuple...) = Base.vcat(vars[1], vars[2], vars[3:end]...)
+# Also support concatenating more than 2 blocks at once using varargs.
+# Restricted to @variables-shaped tuples to avoid type-piracy (see note above).
+Base.vcat(vars::Tuple{Priors,Derived,Vararg}...) = Base.vcat(vars[1], vars[2], vars[3:end]...)


### PR DESCRIPTION
Two latent issues prevented Octofitter models from sampling under Pigeons'
`MPIProcesses` (MPI), where child processes load a minimal set of packages,
sometimes from source. Both are no-ops for existing single-process usage.

### 1. `Base.vcat(::Tuple, ...)` type piracy (`src/macros.jl`)
The methods that combine `@variables` blocks dispatched on *any* tuples, so they
hijacked unrelated tuple `vcat`/matrix-literal calls in other packages — e.g.
SIMD.jl's `const CAST_SIZE_CHANGE_FLOAT = [(:fptrunc, >); (:fpext, <)]` — throwing
`ArgumentError: First argument does not appear to be from @variables macro`
whenever such a package is loaded **from source**. That is exactly what Pigeons MPI
children do under `--compiled-modules=no` (Julia < 1.11), so `using Octofitter`
dies in every rank.

Fix: restrict dispatch to `Tuple{Priors,Derived,Vararg}` (the `@variables` output
shape). Since `Priors`/`Derived` are Octofitter-owned types this is no longer
piracy, and ordinary tuples fall through to `Base.vcat`.

### 2. `haskey(::Vector, ::Int)` in `OctofitterPigeonsExt`
`Pigeons.initialization` validated the chain index with
`!haskey(model.starting_points, chain_no)`, but `starting_points::Union{Nothing,Vector}`
is a `Vector`, for which `haskey` is undefined. It only worked when some other
loaded package happened to provide such a method; the minimal MPI-child package set
exposes it as `MethodError: no method matching haskey(::Vector{Vector{Float64}}, ::Int64)`.

Fix: use `checkbounds(Bool, model.starting_points, chain_no)`.

### Testing
Verified on the Fir (Digital Research Alliance) cluster: with these fixes a
3-planet `AbsoluteVisual{KepOrbit}` + RV + G23H astrometry model samples over MPI
via `MPIProcesses` across 8 chains, with 4 Kepler-solver threads per chain, and
loads back to MCMCChains. Single-process `octofit`/`octofit_pigeons` runs are
unaffected.