### PR TITLE
Document show_absastrom flag for the G23H astrometry panel in octoplot

### DIFF
--- a/docs/src/octoplot.md
+++ b/docs/src/octoplot.md
@@ -25,7 +25,8 @@ fig = octoplot(model, chain;
     show_astrom_time=true,    # Show sep/PA vs time
     show_rv=true,             # Show stellar RV
     show_relative_rv=true,    # Show planet-star relative RV
-    show_pma=true,            # Show proper motion anomaly
+    show_pma=true,            # Show proper motion anomaly (HGCA)
+    show_absastrom=true,      # Show absolute astrometry / proper motion (G23H)
     show_mass=true            # Show mass posterior
 )
 ```

--- a/ext/OctofitterMakieExt/octoplot.jl
+++ b/ext/OctofitterMakieExt/octoplot.jl
@@ -13,7 +13,8 @@ this by passing `fname="fname.png"`
 - `show_astrom_time=true`: Separation/PA vs time
 - `show_rv=true`: Stellar RV curve
 - `show_relative_rv=true`: Planet-star relative RV
-- `show_pma=true`: Proper motion anomaly (also governs the G23H absolute-astrometry panel)
+- `show_pma=true`: Proper motion anomaly (HGCA)
+- `show_absastrom=true`: Absolute astrometry / proper motion (G23H)
 - `show_mass=true`: Mass posterior
 
 # Optional Arguments
@@ -150,12 +151,6 @@ function Octofitter.octoplot!(
         end
     end
 
-    # Capture whether the user explicitly requested proper-motion panels.
-    # The G23H absolute-astrometry panel (`show_absastrom`) is also a
-    # proper-motion-anomaly panel, so an explicit `show_pma` value should
-    # govern it too (e.g. `show_pma=false` should suppress it).
-    show_pma_explicit = show_pma
-
     if isnothing(show_pma)
         show_pma = false
         for like_obj in model.system.observations
@@ -175,12 +170,6 @@ function Octofitter.octoplot!(
         show_absastrom = false
         for like_obj in model.system.observations
             show_absastrom |= like_obj isa Octofitter.G23HObs
-        end
-        # The G23H panel is a proper-motion-anomaly panel, so honor an
-        # explicit `show_pma` setting: `show_pma=false` suppresses it and
-        # `show_pma=true` only shows it when G23H data is actually present.
-        if !isnothing(show_pma_explicit)
-            show_absastrom &= show_pma_explicit
         end
     end
 

--- a/ext/OctofitterMakieExt/octoplot.jl
+++ b/ext/OctofitterMakieExt/octoplot.jl
@@ -13,7 +13,7 @@ this by passing `fname="fname.png"`
 - `show_astrom_time=true`: Separation/PA vs time
 - `show_rv=true`: Stellar RV curve
 - `show_relative_rv=true`: Planet-star relative RV
-- `show_pma=true`: Proper motion anomaly
+- `show_pma=true`: Proper motion anomaly (also governs the G23H absolute-astrometry panel)
 - `show_mass=true`: Mass posterior
 
 # Optional Arguments
@@ -150,6 +150,12 @@ function Octofitter.octoplot!(
         end
     end
 
+    # Capture whether the user explicitly requested proper-motion panels.
+    # The G23H absolute-astrometry panel (`show_absastrom`) is also a
+    # proper-motion-anomaly panel, so an explicit `show_pma` value should
+    # govern it too (e.g. `show_pma=false` should suppress it).
+    show_pma_explicit = show_pma
+
     if isnothing(show_pma)
         show_pma = false
         for like_obj in model.system.observations
@@ -169,6 +175,12 @@ function Octofitter.octoplot!(
         show_absastrom = false
         for like_obj in model.system.observations
             show_absastrom |= like_obj isa Octofitter.G23HObs
+        end
+        # The G23H panel is a proper-motion-anomaly panel, so honor an
+        # explicit `show_pma` setting: `show_pma=false` suppresses it and
+        # `show_pma=true` only shows it when G23H data is actually present.
+        if !isnothing(show_pma_explicit)
+            show_absastrom &= show_pma_explicit
         end
     end
 


### PR DESCRIPTION
## Summary

A user reported that the G23H proper-motion panel always appears in `octoplot`, even when passing `show_pma=false` — unlike the equivalent HGCA panel.

The cause: the G23H panel (`absastromplot!`) is controlled by its own keyword, **`show_absastrom`**, which auto-enables whenever a `G23HObs` likelihood is present. This flag was undocumented, so users reasonably expected `show_pma` to control it.

## Change

Keep `show_absastrom` as a separate, independent control (its existing auto-detection behavior is unchanged) and document it alongside the other panel flags:

- Added `show_absastrom` to the `octoplot` docstring panel list.
- Added it to the `octoplot.md` docs page example.
- Clarified that `show_pma` is the HGCA proper-motion panel and `show_absastrom` is the G23H absolute-astrometry / proper-motion panel.

Users who want to hide the G23H panel can now pass `show_absastrom=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017yMPwamdw436QvzdF8aoyP)_