### PR TITLE
Perf/g23h lnlike optimizations

### DIFF
--- a/src/likelihoods/g23h.jl
+++ b/src/likelihoods/g23h.jl
@@ -32,9 +32,15 @@ The G23H catalog (~14 GB) is automatically downloaded on first use.
 Default priors are set automatically from the catalog. Custom priors can be specified:
 ```julia
 variables=@variables begin
-    fluxratio ~ Product([LogUniform(1e-6, 1e-1) for _ in 1:N_planets])  # For luminous companions
-    σ_att ~ LogUniform(0.01, 1.0)     # Attitude error (mas)
-    σ_AL ~ LogUniform(0.01, 1.0)      # Along-scan error (mas)
+    # G-band flux ratio per companion — used for the Gaia DR2/DR3 photocentre
+    fluxratio     ~ Product([LogUniform(1e-6, 1e-1) for _ in 1:N_planets])
+    # Hp-band flux ratio per companion — used for the Hipparcos abscissa branch.
+    # Required for any star with `has_hipparcos`. The Hipparcos likelihood uses
+    # this value with the BINARYS atan2 photocentre formula and σ inflation
+    # (Leclerc et al. 2023, A&A 672 A82).
+    fluxratio_hip ~ Product([LogUniform(1e-6, 1e-1) for _ in 1:N_planets])
+    σ_att   ~ LogUniform(0.01, 1.0)   # Attitude error (mas)
+    σ_AL    ~ LogUniform(0.01, 1.0)   # Along-scan error (mas)
     σ_calib ~ LogUniform(0.01, 1.0)   # Calibration error (mas)
 end
 ```
@@ -1289,32 +1295,38 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
     else
 
 
+        # Per-transit σ-inflation buffer for the BINARYS first-harmonic correction
+        # (Leclerc et al. 2023, Eq. 15). Initialised to 1 and accumulated
+        # multiplicatively per (luminous) planet; for non-luminous companions
+        # f_σ = 1 so it stays unchanged.
+        n_hip = length(like.hip_table.epoch)
+        σ_inflation_hip = ones(T, n_hip)
+
         for (i_planet,(orbit, θ_planet)) in enumerate(zip(orbits, θ_system.planets))
             planet_mass_msol = θ_planet.mass*Octofitter.mjup2msol
             if planet_mass_msol == 0.0
                 continue
             end
-            if hasproperty(θ_obs, :fluxratio)
-                if θ_obs.fluxratio isa Number
-                    fluxratio = θ_obs.fluxratio
-                else
-                    fluxratio = θ_obs.fluxratio[i_planet]
-                end
-            else
-                fluxratio = 0.0
-            end
+            # Hp-band per-companion flux ratio (M_Hp-derived). Required: this
+            # branch always uses BINARYS, which requires the Hp light fraction.
+            fluxratio_hip = θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip :
+                            θ_obs.fluxratio_hip[i_planet]
             _simulate_skypath_perturbations!(
                 Δα_mas_hip, Δδ_mas_hip,
                 like.hip_table, orbit,
-                planet_mass_msol, fluxratio,
+                planet_mass_msol, fluxratio_hip,
                 orbit_solutions[i_planet],
-                -1, T
+                -1, T;
+                grid_step_arcsec = HIPPARCOS_GRID_STEP_ARCSEC,
+                σ_inflation = σ_inflation_hip,
             )
         end
+        # Inflate per-transit σ_residual by the BINARYS first-harmonic factor before LSQ.
+        sres_inflated = like.hip_table.sres .* σ_inflation_hip
         if like.include_iad
-            out = fit_5param_prepared(like.A_prepared_5_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, like.hip_table.res, like.hip_table.sres)
+            out = fit_5param_prepared(like.A_prepared_5_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, like.hip_table.res, sres_inflated)
         else
-            out = fit_5param_prepared(like.A_prepared_5_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip)
+            out = fit_5param_prepared(like.A_prepared_5_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, 0.0, sres_inflated)
         end
         Δα_h, Δδ_h, Δpmra_h, Δpmdec_h = out.parameters
         α_h₀, δ_h₀, pmra_h₀, pmdec_h₀ = propagate_astrom(orbits, like.catalog.epoch_ra_hip_mjd, like.catalog.epoch_dec_hip_mjd)
@@ -1770,22 +1782,23 @@ function Octofitter.generate_from_params(like::G23HObs, ctx::SystemObservationCo
     if has_hip && n_hip > 0
         Δα_hip = zeros(n_hip)
         Δδ_hip = zeros(n_hip)
+        σ_inflation_hip = ones(n_hip)
         for (i_planet, (orbit, θ_planet)) in enumerate(zip(orbits, θ_system.planets))
             planet_mass_msol = θ_planet.mass * Octofitter.mjup2msol
             if planet_mass_msol == 0.0
                 continue
             end
-            fluxratio = if hasproperty(θ_obs, :fluxratio)
-                θ_obs.fluxratio isa Number ? θ_obs.fluxratio : θ_obs.fluxratio[i_planet]
-            else
-                0.0
-            end
+            # Hp-band per-companion flux ratio: required for the BINARYS Hipparcos branch.
+            fluxratio_hip = θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip :
+                            θ_obs.fluxratio_hip[i_planet]
             _simulate_skypath_perturbations!(
                 Δα_hip, Δδ_hip,
                 like.hip_table, orbit,
-                planet_mass_msol, fluxratio,
+                planet_mass_msol, fluxratio_hip,
                 orbit_solutions[i_planet],
-                -1, Float64
+                -1, Float64;
+                grid_step_arcsec = HIPPARCOS_GRID_STEP_ARCSEC,
+                σ_inflation = σ_inflation_hip,
             )
         end
 
@@ -1802,8 +1815,10 @@ function Octofitter.generate_from_params(like::G23HObs, ctx::SystemObservationCo
         # Curvature residual = perturbation - linear model
         new_hip_res .= b_hip .- model_hip
         if add_noise
+            # Inflate per-transit residual σ by the BINARYS first-harmonic factor
+            # (Leclerc et al. 2023, Eq. 15) when generating synthetic noise.
             for i in 1:n_hip
-                new_hip_res[i] += randn() * like.hip_table.sres_renorm[i]
+                new_hip_res[i] += randn() * like.hip_table.sres_renorm[i] * σ_inflation_hip[i]
             end
         end
     end

--- a/src/likelihoods/g23h.jl
+++ b/src/likelihoods/g23h.jl
@@ -58,7 +58,28 @@ struct G23HObs{TTable,TTableH,TTableG,TCat,THip} <: AbstractObs
     A_prepared_5_dr3::Matrix{Float64}
     include_iad::Bool
     ueva_mode::Symbol
+    # Cached weighted pseudo-inverse for the Hipparcos 5-param fit:
+    # Q = pinv(A_prepared_5_hip ./ sres) ./ sres', so the per-call weighted
+    # LSQ reduces to a single 5×N matrix-vector multiply.  Both A and σ are
+    # fixed at construction, so this is initialised eagerly by the
+    # constructors (the lazy `_ensure_pinv_5_hip!` path remains only as a
+    # fallback and to keep `simulate!` self-contained).  The empty 0×0
+    # sentinel indicates "uninitialised".
+    _pinv_5_hip::Base.RefValue{Matrix{Float64}}
+    # Cached Hipparcos catalog-residual 5-param fit: x_const = Q_hip * residuals
+    # where residuals = like.hip_table.res (when include_iad=true) or zero.
+    # Used in the all-inactive (n=0) simulate! fast path to skip a per-call
+    # matrix-vector multiply.  Initialised eagerly alongside _pinv_5_hip.
+    _hip_x_const::Base.RefValue{NTuple{4, Float64}}
+    _hip_x_const_initialised::Base.RefValue{Bool}
 end
+
+# G23H short-circuits on mass == 0 everywhere it consumes per-planet orbit
+# solutions (DR2/DR3 skypath perturbations, the Hippacentre combined loop,
+# and the Gaia RV simulation all `continue` on zero-mass companions), so
+# `make_ln_like` may safely elide the per-epoch Kepler solves for absent
+# companions.
+requires_solutions_for_zero_mass(::G23HObs) = false
 
 
 function likelihoodname(like::G23HObs)
@@ -559,7 +580,7 @@ function G23HObs(;
     (priors,derived)=variables
 
 
-    return G23HObs{
+    obj = G23HObs{
         typeof(table),
         typeof(hip_table),
         typeof(gaia_table),
@@ -578,7 +599,16 @@ function G23HObs(;
         A_prepared_5_dr3,
         include_iad,
         ueva_mode,
+        Ref{Matrix{Float64}}(zeros(0, 0)),
+        Ref{NTuple{4, Float64}}((0.0, 0.0, 0.0, 0.0)),
+        Ref{Bool}(false),
     )
+    # Eagerly initialise the cached Hipparcos weighted pseudo-inverse and
+    # catalog-residual projection so no lazy mutation happens during
+    # (possibly multi-threaded) sampling.
+    _ensure_pinv_5_hip!(obj)
+    _ensure_hip_x_const!(obj)
+    return obj
 
 end
 
@@ -606,7 +636,7 @@ function Octofitter.likeobj_from_epoch_subset(like::G23HObs, obs_inds)
         )
         catalog = (;catalog..., dist_hip = nothing, dist_hg=nothing)
     end
-    return G23HObs{
+    obj = G23HObs{
         typeof(table),
         typeof(hip_table),
         typeof(gaia_table),
@@ -625,11 +655,66 @@ function Octofitter.likeobj_from_epoch_subset(like::G23HObs, obs_inds)
         A_prepared_5_dr3,
         include_iad,
         ueva_mode,
+        Ref{Matrix{Float64}}(zeros(0, 0)),
+        Ref{NTuple{4, Float64}}((0.0, 0.0, 0.0, 0.0)),
+        Ref{Bool}(false),
     )
+    _ensure_pinv_5_hip!(obj)
+    _ensure_hip_x_const!(obj)
+    return obj
+end
+
+function _ensure_pinv_5_hip!(like::G23HObs)
+    # Hip fit uses *per-epoch* σ from like.hip_table.sres, so the LSQ is
+    # weighted: x = (Aᵀ W A)⁻¹ Aᵀ W b with W = diag(1/σ_i²). Both A and σ
+    # are fixed at construction, so we can cache `Q = pinv(A/σ) ./ σ'` —
+    # one matvec `Q · b_orig` then reproduces the weighted-LSQ x exactly.
+    if isempty(like._pinv_5_hip[]) && !isempty(like.A_prepared_5_hip)
+        σ_hip = like.hip_table.sres
+        A = like.A_prepared_5_hip
+        # A_scaled[i, j] = A[i, j] / σ[i] (row-wise scale).  Then
+        # Q = pinv(A_scaled) is 5×n; weight back to x = Q·(b/σ) form by
+        # dividing each column by σ once at construction.
+        A_scaled = A ./ σ_hip
+        Q = pinv(A_scaled) ./ permutedims(σ_hip)
+        like._pinv_5_hip[] = Q
+    end
+    return like._pinv_5_hip[]
+end
+
+# Cache the Hipparcos catalog-residual LSQ projection x_const = Q_hip * b_const
+# where b_const = (Δα·cosϕ + Δδ·sinϕ + residuals) evaluated at zero
+# perturbations (Δα = Δδ = 0).  When include_iad=true, residuals = hip_table.res
+# (constant catalog residuals); otherwise residuals = 0 and x_const is zero.
+# Used in the all-inactive simulate! fast path.  Returned in
+# fit_5param_pinv's reordered convention: (Δα_h, Δδ_h, Δpmra_h, Δpmdec_h).
+function _ensure_hip_x_const!(like::G23HObs)
+    if like._hip_x_const_initialised[]
+        return like._hip_x_const[]
+    end
+    if isempty(like.A_prepared_5_hip) || isnothing(like.catalog.dist_hip)
+        like._hip_x_const[] = (0.0, 0.0, 0.0, 0.0)
+        like._hip_x_const_initialised[] = true
+        return like._hip_x_const[]
+    end
+    Q_hip = _ensure_pinv_5_hip!(like)
+    n_obs = size(like.hip_table, 1)
+    if like.include_iad
+        residuals = like.hip_table.res
+        # b = 0 + 0 + residuals; x_buf = Q_hip * residuals (5-vector)
+        x_buf = Q_hip * residuals
+        # fit_5param_pinv reorders parameters as (x[1], x[2], x[4], x[5], x[3])
+        # but only returns the first 4 in (Δα, Δδ, Δpmra, Δpmdec) form
+        like._hip_x_const[] = (x_buf[1], x_buf[2], x_buf[4], x_buf[5])
+    else
+        like._hip_x_const[] = (0.0, 0.0, 0.0, 0.0)
+    end
+    like._hip_x_const_initialised[] = true
+    return like._hip_x_const[]
 end
 
 function ln_like(like::G23HObs, ctx::SystemObservationContext)
-    (; θ_system, θ_obs, orbits, orbit_solutions, orbit_solutions_i_epoch_start) = ctx 
+    (; θ_system, θ_obs, orbits, orbit_solutions, orbit_solutions_i_epoch_start) = ctx
 
     T = _system_number_type(θ_system)
     ll = zero(T)
@@ -808,26 +893,54 @@ function ln_like(like::G23HObs, ctx::SystemObservationContext)
                 :ueva_dr3
             ]
 
-            # Build index mask for which components are present
-            mask = [flag ∈ like.table.kind for flag in component_flags]
-            indices = findall(mask)
-            n_components = length(indices)
+            # Build index mask for which components are present.
+            # `like.table.kind` is fixed at construction time but we lack a
+            # cached form here, so we compute mask/indices into bump-allocated
+            # buffers (already inside @no_escape) instead of heap-allocating
+            # a Vector{Bool} + Vector{Int} per call.
+            mask = @alloc(Bool, 11)
+            @inbounds for i in 1:11
+                mask[i] = component_flags[i] ∈ like.table.kind
+            end
+            n_components = 0
+            @inbounds for i in 1:11
+                n_components += mask[i]
+            end
+            indices = @alloc(Int, n_components)
+            let k = 0
+                @inbounds for i in 1:11
+                    if mask[i]
+                        k += 1
+                        indices[k] = i
+                    end
+                end
+            end
 
             # We handle the iad separately from the big covariance matrix below, since it's not correlated
             # and we don't want to factorize a massively bigger matrix than necessary
             if :iad_hip ∈ like.table.kind
-                 for i in eachindex(iad_resid)
-                    if like.hip_table.reject[i]
-                        continue
-                    end
-                    (;hip_iad_jitter) = θ_obs
+                # Hoist `hip_iad_jitter` extraction and the Normal logpdf
+                # constant `-½log(2π)` out of the per-epoch loop, and inline
+                # the logpdf math to skip the `Normal(0, σ_iad)` constructor.
+                # Work in σ_iad² instead of σ_iad to drop the hypot's sqrt
+                # and use log(σ²)·½ in place of log(σ).  Math:
+                #   -½(z² + log σ²) - ½log 2π   where z² = r² / σ²
+                # is algebraically identical to the original
+                #   -½ z² - log σ - ½log 2π     with z = r/σ.
+                (;hip_iad_jitter) = θ_obs
+                _half_log2π = T(0.5) * log(T(2π))
+                jitter_sq = hip_iad_jitter * hip_iad_jitter
+                @inbounds for i in eachindex(iad_resid)
+                    like.hip_table.reject[i] && continue
                     # Inflate per-transit residual σ by the BINARYS first-harmonic
                     # factor (Leclerc et al. 2023, Eq. 15). σ_inflation_hip[i] = 1
                     # in the unresolved limit and grows where the binary modulation
                     # reduces the signal amplitude — the IAD residual noise scales
                     # the same way.
-                    σ_iad = hypot(like.hip_table.sres_renorm[i] * σ_inflation_hip[i], hip_iad_jitter)
-                    ll += logpdf(Normal(0, σ_iad), iad_resid[i])
+                    s = like.hip_table.sres_renorm[i] * σ_inflation_hip[i]
+                    σ_iad_sq = s * s + jitter_sq
+                    r = iad_resid[i]
+                    ll += -T(0.5) * (r * r / σ_iad_sq + log(σ_iad_sq)) - _half_log2π
                 end
             end
 
@@ -1047,49 +1160,62 @@ function ln_like(like::G23HObs, ctx::SystemObservationContext)
                 UEVA_model                # ueva_dr3 model value
             ]
 
-            # Extract selected components
-            μ_catalog_selected = μ_catalog_full[indices]
-            μ_model_selected = μ_model_full[indices]
-
-            # Build full covariance matrix (11x11)
-            # Initialize with zeros
-            Σ_full = zeros(T, 11, 11)
-
-            # Fill in the block diagonal elements (within-epoch covariances)
+            # Build the full covariance matrix into a Bumper-allocated buffer
+            # (we're already inside @no_escape — no heap allocation).
+            Σ_full = @alloc(T, 11, 11); fill!(Σ_full, zero(T))
             Σ_full[1:2, 1:2] .= Σ_h     # Hipparcos
             Σ_full[3:4, 3:4] .= Σ_hg    # HGCA
             Σ_full[5:6, 5:6] .= Σ_dr2   # DR2
             Σ_full[7:8, 7:8] .= Σ_dr32  # DR3-DR2
             Σ_full[9:10, 9:10] .= Σ_dr3 # DR3
-
-            # UEVA variance
             Σ_full[11, 11] = UEVA_unc^2
-
-            # Add cross-epoch correlations between DR2 and DR3
-            
-            # Compute the cross-correlation matrix K
+            # Cross-epoch correlations between DR2 and DR3
             K = ρ_dr3_dr2 * sqrt(Σ_dr2) * sqrt(Σ_dr3)'
-            
-            # Fill in the cross-correlation blocks
-            Σ_full[5:6, 9:10] .= K      # DR2 -> DR3
-            Σ_full[9:10, 5:6] .= K'     # DR3 -> DR2 (transpose)
+            Σ_full[5:6, 9:10] .= K
+            Σ_full[9:10, 5:6] .= K'
 
-            # Extract the submatrix for selected components
-            Σ_selected = Σ_full[indices, indices]
-
-            # @show (μ_catalog_selected .- μ_model_selected ) ./ sqrt.(diag(Σ_selected))
-            # @show μ_catalog_selected μ_model_selected
+            # Extract selected components into Bumper-allocated scratch.
+            μ_catalog_selected = @alloc(T, n_components)
+            μ_model_selected = @alloc(T, n_components)
+            @inbounds for k in 1:n_components
+                μ_catalog_selected[k] = μ_catalog_full[indices[k]]
+                μ_model_selected[k] = μ_model_full[indices[k]]
+            end
+            Σ_selected = @alloc(T, n_components, n_components)
+            @inbounds for kj in 1:n_components, ki in 1:n_components
+                Σ_selected[ki, kj] = Σ_full[indices[ki], indices[kj]]
+            end
 
             # Compute likelihood
             if n_components == 1
-                # Single component - use univariate normal
                 ll += logpdf(Normal(μ_catalog_selected[1], sqrt(Σ_selected[1,1])), μ_model_selected[1])
             else
-                # Multiple components - use multivariate normal
-                local dist_selected
+                # Manual MvNormal logpdf via in-place cholesky on a Bumper
+                # buffer — skips the heap-allocating PDMat wrapper inside
+                # `Distributions.MvNormal`, which re-factorises Σ on every
+                # call. Math: log p = -½(δ'Σ⁻¹δ + n·log(2π) + log|Σ|),
+                # with δ'Σ⁻¹δ = ||L⁻¹δ||² and log|Σ| = 2·Σ log(L_ii).
+                L_buf = @alloc(T, n_components, n_components)
+                @inbounds for kj in 1:n_components, ki in 1:n_components
+                    L_buf[ki, kj] = Σ_selected[ki, kj]
+                end
+                δ_buf = @alloc(T, n_components)
+                @inbounds for k in 1:n_components
+                    δ_buf[k] = μ_model_selected[k] - μ_catalog_selected[k]
+                end
                 try
-                    dist_selected = MvNormal(μ_catalog_selected, Hermitian(Σ_selected))
-                    ll += logpdf(dist_selected, μ_model_selected)
+                    chol_F = cholesky!(Hermitian(L_buf, :L))
+                    ldiv!(chol_F.L, δ_buf)
+                    quad = zero(T)
+                    @inbounds for k in 1:n_components
+                        quad += δ_buf[k] * δ_buf[k]
+                    end
+                    logdet_Σ = zero(T)
+                    @inbounds for k in 1:n_components
+                        logdet_Σ += log(L_buf[k, k])
+                    end
+                    logdet_Σ *= 2
+                    ll += -T(0.5) * (quad + n_components * log(T(2π)) + logdet_Σ)
                 catch err
                     if err isa PosDefException
                         ll = convert(T, -Inf)
@@ -1227,6 +1353,174 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
         # for different planets?
     end
 
+    # Fast path: all companions inactive (mass == 0).  Triggered by the
+    # n_planets prior's P(N=0)=0.5 + the active-flag pp_*=0 multiplier in the
+    # @variables block, so ~50% of prior draws (and most of the chain volume
+    # for sparse-companion stars) skip the full simulate! body.  In the
+    # all-inactive limit:
+    #   * every per-transit perturbation Δα_mas_*/Δδ_mas_* is exactly 0;
+    #   * the DR3/DR2 5-param fits on zero data return parameters = 0 and
+    #     chi_squared_astro = 0, so UEVA_model_raw = 0;
+    #   * the Hippacentre combined loop early-exits with σ_inflation = 1;
+    #   * the Hipparcos 5-param fit collapses to the catalog-residual
+    #     projection x_const = Q_hip * residuals, cached at construction
+    #     since it depends only on hip_table.res (constant);
+    #   * RV simulation produces an all-zero rv_model ⇒ sample_variance = 0.
+    # We restrict the fast path to non-AbsoluteVisual orbits — AbsoluteVisual
+    # needs the per-epoch propagate_astrom (barycentric motion, differential
+    # light-travel time), which doesn't simplify under all-inactive.
+    all_inactive = !absolute_orbits
+    if all_inactive
+        @inbounds for i in eachindex(orbits)
+            if θ_system.planets[i].mass != zero(θ_system.planets[i].mass)
+                all_inactive = false
+                break
+            end
+        end
+    end
+
+    if all_inactive
+        # Hipparcos catalog-residual cached LSQ projection.
+        x_const = _ensure_hip_x_const!(like)
+        Δα_h     = T(x_const[1])
+        Δδ_h     = T(x_const[2])
+        Δpmra_h  = T(x_const[3])
+        Δpmdec_h = T(x_const[4])
+
+        # IAD residual loop — identical to the slow path's loop but reading
+        # Δα_mas_hip = Δδ_mas_hip ≡ 0 and σ_inflation_hip ≡ 1.
+        if !isnothing(like.catalog.dist_hip)
+            (;iad_Δra, iad_Δdec, iad_pmra, iad_pmdec, iad_Δplx) = θ_obs
+            plx_at_epoch = like.hip_sol.plx + iad_Δplx
+            inv_julian_year = inv(julian_year)
+            iad_pmra_eff  = iad_pmra  - Δpmra_h
+            iad_pmdec_eff = iad_pmdec - Δpmdec_h
+            iad_Δra_eff   = iad_Δra   - Δα_h
+            iad_Δdec_eff  = iad_Δdec  - Δδ_h
+            hip_epoch    = like.hip_table.epoch
+            hip_cosϕ     = like.hip_table.cosϕ
+            hip_sinϕ     = like.hip_table.sinϕ
+            hip_plxFact  = like.hip_table.parallaxFactorAlongScan
+            hip_projMeas = like.hip_table.proj_meas_alongscan
+            @inbounds @simd for i_epoch in eachindex(hip_epoch, iad_resid)
+                cosϕ = hip_cosϕ[i_epoch]
+                sinϕ = hip_sinϕ[i_epoch]
+                Δt = (hip_epoch[i_epoch] - hipparcos_catalog_epoch_mjd) * inv_julian_year
+                α_off = iad_Δra_eff  + Δt * iad_pmra_eff
+                δ_off = iad_Δdec_eff + Δt * iad_pmdec_eff
+                proj_model = α_off * cosϕ + δ_off * sinϕ + plx_at_epoch * hip_plxFact[i_epoch]
+                iad_resid[i_epoch] = abs(hip_projMeas[i_epoch] - proj_model)
+            end
+            μ_h_fast = @SVector [θ_system.pmra + Δpmra_h, θ_system.pmdec + Δpmdec_h]
+            hip_bias_pm_sq = Δpmra_h*Δpmra_h + Δpmdec_h*Δpmdec_h
+        else
+            μ_h_fast = @SVector [zero(T), zero(T)]
+            hip_bias_pm_sq = zero(T)
+        end
+
+        pmra_sys = θ_system.pmra
+        pmdec_sys = θ_system.pmdec
+        μ_zero = @SVector [pmra_sys, pmdec_sys]
+        μ_dr3_fast  = μ_zero
+        μ_dr2_fast  = μ_zero
+        # Mirror the slow path's HG model PM exactly (non-absolute branch):
+        # with all perturbations zero, Δα_dr3 = Δδ_dr3 = 0, but the Hipparcos
+        # catalog-residual projection (Δα_h, Δδ_h) = x_const[1:2] can be
+        # nonzero, and it enters μ_hg through the long HG baseline.  Keep the
+        # exact operation order of the slow path so the two are bit-identical.
+        μ_hg_fast = if isnothing(like.catalog.dist_hip)
+            @SVector [zero(T), zero(T)]
+        else
+            @SVector [
+                (zero(T) - Δα_h) / (
+                    like.catalog.epoch_ra_dr3_mjd - like.catalog.epoch_ra_hip_mjd
+                )*julian_year + pmra_sys,
+                (zero(T) - Δδ_h) / (
+                    like.catalog.epoch_dec_dr3_mjd - like.catalog.epoch_dec_hip_mjd
+                )*julian_year + pmdec_sys,
+            ]
+        end
+        μ_dr32_fast = μ_zero
+
+        istart_dr3 = findfirst(>=(meta_gaia_DR3.start_mjd), vec(gaia_table.epoch))
+        iend_dr3 = findlast(<=(meta_gaia_DR3.stop_mjd), vec(gaia_table.epoch))
+        if isnothing(istart_dr3); istart_dr3 = 1; end
+        if isnothing(iend_dr3); iend_dr3 = length(gaia_table.epoch); end
+        istart_dr2 = findfirst(>=(meta_gaia_DR2.start_mjd), vec(gaia_table.epoch))
+        iend_dr2 = findlast(<=(meta_gaia_DR2.stop_mjd), vec(gaia_table.epoch))
+        if isnothing(istart_dr2); istart_dr2 = 1; end
+        if isnothing(iend_dr2); iend_dr2 = length(gaia_table.epoch); end
+
+        (;astrometric_chi2_al_dr3, astrometric_n_good_obs_al_dr3,
+           astrometric_matched_transits_dr3, astrometric_excess_noise_dr3, ruwe_dr3) = like.catalog
+        N = astrometric_n_good_obs_al_dr3
+        N_FoV = astrometric_matched_transits_dr3
+        N_AL = N / N_FoV
+        if like.ueva_mode == :EAN
+            UEVA_Gaia = astrometric_excess_noise_dr3^2 + σ_att^2 + σ_AL^2
+        elseif like.ueva_mode == :RUWE
+            u0 = 1/ruwe_dr3 * sqrt(astrometric_chi2_al_dr3/(N - gaia_n_dof))
+            UEVA_Gaia = (ruwe_dr3 * u0)^2 * σ_formal^2
+        else
+            error("Unsupported mode (should be :EAN or :RUWE, was $(like.ueva_mode)")
+        end
+        μ_UEVA_single = (N_AL / (N - gaia_n_dof)) *
+                    ((N_FoV - gaia_n_dof) * σ_calib^2 + N_FoV * σ_AL^2)
+        σ_UEVA_single = sqrt(
+            2 * N_AL / (N - gaia_n_dof)^2 * (
+                N_AL * (N_FoV - gaia_n_dof) * σ_calib^4 +
+                N_FoV * σ_AL^4 +
+                2 * N_FoV * σ_AL^2 * σ_calib^2
+            )
+        )
+        μ_1_3 = UEVA_Gaia^(1/3)
+        UEVA_unc = σ_UEVA_single * μ_UEVA_single^(-2/3) / 3
+        # chi_squared_astro = 0 ⇒ UEVA_model_1 = 0 ⇒ UEVA_model = cbrt(μ_UEVA_single)
+        UEVA_model = cbrt(μ_UEVA_single)
+        deflation_factor_raw = sqrt(μ_UEVA_single / UEVA_Gaia)
+        deflation_factor_dr3 = deflation_factor_raw > 1.0 ? 1.0 : deflation_factor_raw
+
+        if :rv_dr3 ∈ like.table.kind
+            N_rv = like.catalog.rv_nb_transits
+            rv_dof_fast = N_rv - 1
+            ε_catalog = like.catalog.radial_velocity_error
+            s_catalog_squared_fast = (2 * N_rv / π) * (ε_catalog^2 - 0.113^2)
+            rv_mean_fast = zero(T)
+            sample_variance_fast = zero(T)
+        else
+            rv_dof_fast = convert(T, NaN)
+            s_catalog_squared_fast = convert(T, NaN)
+            rv_mean_fast = convert(T, NaN)
+            sample_variance_fast = convert(T, NaN)
+        end
+
+        return (;
+            UEVA_model,
+            UEVA_unc,
+            μ_1_3,
+            μ_h = μ_h_fast,
+            μ_hg = μ_hg_fast,
+            μ_dr2 = μ_dr2_fast,
+            μ_dr32 = μ_dr32_fast,
+            μ_dr3 = μ_dr3_fast,
+            μ = (@SVector [μ_h_fast[1],μ_h_fast[2],μ_hg_fast[1],μ_hg_fast[2],μ_dr2_fast[1],μ_dr2_fast[2],μ_dr32_fast[1],μ_dr32_fast[2],μ_dr3_fast[1],μ_dr3_fast[2],UEVA_model,sample_variance_fast]),
+            hip_bias_pm_sq,
+            n_dr3 = iend_dr3 - istart_dr3 + 1,
+            n_dr2 = iend_dr2 - istart_dr2 + 1,
+            rv_dof = rv_dof_fast,
+            rv_mean = rv_mean_fast,
+            sample_variance = sample_variance_fast,
+            s_catalog_squared = s_catalog_squared_fast,
+            deflation_factor_dr3,
+            pmra_hip_model = μ_h_fast[1], pmdec_hip_model = μ_h_fast[2],
+            pmra_hg_model = μ_hg_fast[1], pmdec_hg_model = μ_hg_fast[2],
+            pmra_dr2_model = μ_dr2_fast[1], pmdec_dr2_model = μ_dr2_fast[2],
+            pmra_dr32_model = μ_dr32_fast[1], pmdec_dr32_model = μ_dr32_fast[2],
+            pmra_dr3_model = μ_dr3_fast[1], pmdec_dr3_model = μ_dr3_fast[2],
+            Δα_dr3 = zero(T), Δδ_dr3 = zero(T),
+            Δpmra_dr3 = zero(T), Δpmdec_dr3 = zero(T),
+        )
+    end
 
 
     # Helper functions to either get the static pmra from the orbital elements,
@@ -1267,6 +1561,44 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
 
 
 
+    # Pre-compute orbit solutions per active companion at every hip_table +
+    # gaia_table epoch.  Without this cache, simulate! would call orbitsolve
+    # three times per active planet per Hipparcos transit (Hippacentre combined,
+    # ~100 transits) and twice per planet per Gaia transit (DR3 and DR2 paths
+    # iterate over overlapping views into the same gaia_table, so they double-
+    # count the DR2-in-DR3 region).  Layout per planet: indices 1..n_hip = hip
+    # epochs, indices n_hip+1..n_hip+n_gaia = gaia epochs.  Bumper buffer is
+    # the caller's @no_escape (ln_like).  Allocated for every planet (3 in
+    # production) but only populated for active ones; downstream loops skip
+    # mass==0 planets without indexing into the array.
+    n_planets = length(orbits)
+    n_hip_cache = size(like.hip_table, 1)
+    n_gaia_cache = length(gaia_table.epoch)
+    n_total_cache = n_hip_cache + n_gaia_cache
+    _ref_epoch_cache = n_hip_cache > 0 ? like.hip_table.epoch[1] : gaia_table.epoch[1]
+    # NOTE: all companions are assumed to share a single orbit-solution type
+    # (true whenever the planets use the same orbit basis, as in the lumcomp
+    # pipeline). A heterogeneous mix would fail loudly on the setindex!
+    # below, not silently corrupt.
+    _sol0_cache = orbitsolve(first(orbits), _ref_epoch_cache)
+    _SolType = typeof(_sol0_cache)
+    _bumper = Bumper.default_buffer()
+    planet_sols_cache = ntuple(n_planets) do p
+        Bumper.alloc!(_bumper, _SolType, n_total_cache)
+    end
+    @inbounds for p in 1:n_planets
+        if θ_system.planets[p].mass != zero(θ_system.planets[p].mass)
+            sols = planet_sols_cache[p]
+            o = orbits[p]
+            for i in 1:n_hip_cache
+                sols[i] = orbitsolve(o, like.hip_table.epoch[i])
+            end
+            for i in 1:n_gaia_cache
+                sols[n_hip_cache + i] = orbitsolve(o, gaia_table.epoch[i])
+            end
+        end
+    end
+
     ################################
     # DR3
     istart_dr3 = findfirst(>=(meta_gaia_DR3.start_mjd), vec(gaia_table.epoch))
@@ -1278,7 +1610,10 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
         iend_dr3 = length(gaia_table.epoch)
     end
     gaia_table_dr3 = @views gaia_table[istart_dr3:iend_dr3]
-    # gaia_table_dr3.epoch .+= Δepoch_dr3_days
+    # `_simulate_skypath_perturbations!` indexes `orbit_solutions[i_start + i]`
+    # with i in 1:length(table); offset so index lands in the gaia portion at
+    # the istart_dr3 row.
+    _dr3_sol_start = n_hip_cache + istart_dr3 - 1
     for (i_planet,(orbit, θ_planet)) in enumerate(zip(orbits, θ_system.planets))
         planet_mass_msol = θ_planet.mass*Octofitter.mjup2msol
         if planet_mass_msol == 0.0
@@ -1297,8 +1632,8 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
             Δα_mas_dr3, Δδ_mas_dr3,
             gaia_table_dr3, orbit,
             planet_mass_msol, fluxratio,
-            orbit_solutions[i_planet],
-            -1, T,
+            planet_sols_cache[i_planet],
+            _dr3_sol_start, T,
         )
     end
 
@@ -1352,8 +1687,8 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
             Δα_mas_dr2, Δδ_mas_dr2,
             gaia_table_dr2, orbit,
             planet_mass_msol, fluxratio,
-            orbit_solutions[i_planet],
-            -1, T
+            planet_sols_cache[i_planet],
+            n_hip_cache + istart_dr2 - 1, T
         )
     end
 
@@ -1389,7 +1724,6 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
         n_hip = length(like.hip_table.epoch)
         fill!(σ_inflation_hip, one(T))
 
-        n_planets = length(orbits)
         planet_masses_msol_hip = ntuple(i_planet -> θ_system.planets[i_planet].mass * Octofitter.mjup2msol, n_planets)
         # Companions with mass = 0 contribute nothing — zero out their flux ratio so
         # they fall out of both the modulated-signal sum and the host-reflex sum.
@@ -1397,14 +1731,16 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
             planet_masses_msol_hip[i_planet] == 0.0 ? zero(T) :
                 (θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip : θ_obs.fluxratio_hip[i_planet])
         end
-        # G23H pipeline calls per-planet `orbit_solutions[i_planet]` with start index −1
-        orbit_sol_starts_hip = ntuple(_ -> -1, n_planets)
+        # Hippacentre indexes `orbit_solutions_per_planet[k][i_start + i]` for
+        # i in 1:n_hip; with the planet_sols_cache layout (hip rows first),
+        # i_start = 0 maps i directly to the hip portion.
+        orbit_sol_starts_hip = ntuple(_ -> 0, n_planets)
 
         _simulate_skypath_hippacentre_combined!(
             Δα_mas_hip, Δδ_mas_hip, σ_inflation_hip,
             like.hip_table,
             orbits, planet_masses_msol_hip, flux_ratios_hip,
-            orbit_solutions, orbit_sol_starts_hip, T,
+            planet_sols_cache, orbit_sol_starts_hip, T,
             HIPPARCOS_GRID_STEP_ARCSEC,
         )
 
@@ -1413,10 +1749,14 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
         # reproduce the bias it absorbed we must weight the LSQ the same way.
         # σ_inflation_hip is propagated separately into the IAD-residual likelihood
         # (`σ_iad = hypot(sres_renorm * σ_inflation_hip, hip_iad_jitter)` below).
+        # Cached weighted-LSQ path: `_ensure_pinv_5_hip!` returns the
+        # `Q = pinv(A./σ) ./ σ'` matrix, so the LSQ solution is a single
+        # 5×N matrix-vector multiply against the *unscaled* RHS.
+        Q_hip = _ensure_pinv_5_hip!(like)
         if like.include_iad
-            out = fit_5param_prepared(like.A_prepared_5_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, like.hip_table.res, like.hip_table.sres)
+            out = fit_5param_pinv(Q_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, like.hip_table.res)
         else
-            out = fit_5param_prepared(like.A_prepared_5_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, 0.0, like.hip_table.sres)
+            out = fit_5param_pinv(Q_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, 0.0)
         end
         Δα_h, Δδ_h, Δpmra_h, Δpmdec_h = out.parameters
         # Track magnitude of the BINARYS-predicted PM bias for the catalog-
@@ -1459,61 +1799,46 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
             # like.hip_table.res, like.hip_table.sres
             # Δα_mas_hip, Δδ_mas_hip
 
-            α✱_models=[]
-            δ_models=[]
-            for i_epoch in eachindex(like.hip_table.epoch, Δα_mas_hip, Δδ_mas_hip)
-                delta_time_julian_year = (like.hip_table.epoch[i_epoch] - hipparcos_catalog_epoch_mjd) / julian_year
-                plx_at_epoch = like.hip_sol.plx + iad_Δplx
-                # TODO: for very very nearby or high RV objects with specific IDs, our main Hipparcos code correctly
-                # accounts for changing parallax vs time. This does not.
-                α✱_model = iad_Δra - Δα_h + plx_at_epoch * (
-                            like.hip_table.x[i_epoch] * sind(like.hip_sol.radeg) -
-                            like.hip_table.y[i_epoch] * cosd(like.hip_sol.radeg)
-                ) + delta_time_julian_year * (iad_pmra - Δpmra_h)
-                δ_model = iad_Δdec - Δδ_h + plx_at_epoch * (
-                            like.hip_table.x[i_epoch] * cosd(like.hip_sol.radeg) * sind(like.hip_sol.dedeg) +
-                            like.hip_table.y[i_epoch] * sind(like.hip_sol.radeg) * sind(like.hip_sol.dedeg) -
-                            like.hip_table.z[i_epoch] * cosd(like.hip_sol.dedeg)
-                ) + delta_time_julian_year * (iad_pmdec - Δpmdec_h)
-                
-                α✱_model_with_perturbation = α✱_model + Δα_mas_hip[i_epoch]
-                δ_model_with_perturbation = δ_model + Δδ_mas_hip[i_epoch]
+            # Hoist loop-invariant terms.  `hip_sol.plx + iad_Δplx`, the
+            # division by `julian_year`, and the PM-error effective values
+            # are all constant across i_epoch.
+            plx_at_epoch = like.hip_sol.plx + iad_Δplx
+            inv_julian_year = inv(julian_year)
+            iad_pmra_eff  = iad_pmra  - Δpmra_h
+            iad_pmdec_eff = iad_pmdec - Δpmdec_h
+            iad_Δra_eff   = iad_Δra   - Δα_h
+            iad_Δdec_eff  = iad_Δdec  - Δδ_h
 
-                # We've hit the same problem again. As the perturbation gets huge, we
-                # start to need to adjust these parameters to bring the measurements back over to near
-                # the Hipparcos measurements.
-                # But in this case, do we really care? We are only fitting curvature.
-                # Can we subtract the average or something?
-
-
-
-
-                # push!(α✱_models,α✱_model_with_perturbation)
-                # push!(δ_models, δ_model_with_perturbation)
-
-
-                # Calculate differences in milliarcseconds by mapping into a local tangent plane,
-                # with the local coordinate defined by the Hipparcos solution at this *epoch* (not 
-                # at the best solution)
-                point = @SVector [
-                    α✱_model_with_perturbation,
-                    δ_model_with_perturbation,
-                ]
-
-                # Two points defining a line along which the star's position was measured
-                line_point_1 = @SVector [
-                    like.hip_table.α✱ₘ[i_epoch][1],
-                    like.hip_table.δₘ[i_epoch][1],
-                ]
-                line_point_2 = @SVector [
-                    like.hip_table.α✱ₘ[i_epoch][2],
-                    like.hip_table.δₘ[i_epoch][2],
-                ]
-                # Distance from model star Delta position to this line where it was measured 
-                # by the satellite
-                resid = distance_point_to_line(point, line_point_1, line_point_2) # degrees
-
-                iad_resid[i_epoch] = resid
+            # The Hipparcos IAD residual is the perpendicular distance from
+            # the predicted model point (α✱_model_w_p, δ_model_w_p) to the
+            # measured abscissa line, which `distance_point_to_line` evaluates
+            # as |cross(r₂-r₁, r₁-r₀)| / ‖r₂-r₁‖.  By construction the line
+            # endpoints are α✱ₘ = α✱ₐ ± sinϕ and δₘ = δₐ ∓ cosϕ, so r₂-r₁ has
+            # length √(sin²ϕ + cos²ϕ)·2 = 2.  After substituting that and
+            # cancelling the per-axis sinϕ·cosϕ cross-terms, the distance
+            # reduces to the scalar scan-projection
+            #     resid = |α✱ₐ·cosϕ + δₐ·sinϕ
+            #            − (α✱_model_w_p·cosϕ + δ_model_w_p·sinϕ)|
+            # which we evaluate without ever forming the 2D vectors.  The
+            # parallax-along-scan factor is already precomputed in the table
+            # (`parallaxFactorAlongScan`), so the per-epoch x/y/z sind/cosd
+            # multiplies that this loop previously performed collapse to a
+            # single multiply.  α✱ₐ·cosϕ + δₐ·sinϕ = res + Δα✱·cosϕ +
+            # Δδ·sinϕ because α✱ₐ = res·cosϕ + Δα✱ and δₐ = res·sinϕ + Δδ
+            # (cos²+sin² = 1).
+            hip_epoch    = like.hip_table.epoch
+            hip_cosϕ     = like.hip_table.cosϕ
+            hip_sinϕ     = like.hip_table.sinϕ
+            hip_plxFact  = like.hip_table.parallaxFactorAlongScan
+            hip_projMeas = like.hip_table.proj_meas_alongscan
+            @inbounds @simd for i_epoch in eachindex(hip_epoch, Δα_mas_hip, Δδ_mas_hip)
+                cosϕ = hip_cosϕ[i_epoch]
+                sinϕ = hip_sinϕ[i_epoch]
+                Δt = (hip_epoch[i_epoch] - hipparcos_catalog_epoch_mjd) * inv_julian_year
+                α_off = iad_Δra_eff  + Δt * iad_pmra_eff  + Δα_mas_hip[i_epoch]
+                δ_off = iad_Δdec_eff + Δt * iad_pmdec_eff + Δδ_mas_hip[i_epoch]
+                proj_model = α_off * cosϕ + δ_off * sinϕ + plx_at_epoch * hip_plxFact[i_epoch]
+                iad_resid[i_epoch] = abs(hip_projMeas[i_epoch] - proj_model)
             end
 
             # @show θ_system.ra  θ_system.dec iad_Δra iad_Δdec iad_pmra iad_pmdec
@@ -1669,24 +1994,70 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
     if :rv_dr3 ∈ like.table.kind
         σ_rv_per_transit = θ_obs.σ_rv_per_transit  # per-transit RV uncertainty in km/s
 
-        # Simulate RV measurements at Gaia epochs
-        rv_model = zeros(T, length(gaia_table_rv.epoch))
+        # Simulate RV measurements at Gaia epochs — into a bump-allocated
+        # buffer (caller's @no_escape provides the scope) so we don't
+        # heap-alloc a fresh Vector per evaluation, and compute sample
+        # variance with an explicit Welford-style loop to avoid the
+        # `sum((rv_model .- rv_mean).^2)` broadcast temporary.
+        n_rv_ep = length(gaia_table_rv.epoch)
+        rv_model = Bumper.alloc!(Bumper.default_buffer(), T, n_rv_ep)
+        fill!(rv_model, zero(T))
 
-        for (i_planet, (orbit, θ_planet)) in enumerate(zip(orbits, θ_system.planets))
-            planet_mass_msol = θ_planet.mass*Octofitter.mjup2msol
-            if planet_mass_msol == 0.0
-                continue
+        # When `θ_obs.transits_rv` is a prefix of `θ_obs.transits` (guaranteed
+        # for constructor-built variables — both come from partialsortperm of
+        # the same transit_priorities, so the top n_rv selected for RV equal
+        # the first n_rv of the top N_FoV selected for astrometry),
+        # gaia_table_rv.epoch[i] == gaia_table.epoch[i] for i in 1..n_rv_ep.
+        # The planet_sols_cache's gaia portion (rows n_hip+1..n_hip+n_gaia)
+        # thus already holds the required orbit solutions; skip the per-epoch
+        # orbitsolve.  Verify the full epoch prefix (cheap, O(n_rv) compares)
+        # rather than assuming it, so user-supplied `variables` with an
+        # arbitrary transits_rv subset fall back to the exact path.
+        rv_use_cache = n_rv_ep <= n_gaia_cache
+        if rv_use_cache
+            @inbounds for i in 1:n_rv_ep
+                if gaia_table_rv.epoch[i] != gaia_table.epoch[i]
+                    rv_use_cache = false
+                    break
+                end
             end
-            # Accumulate the RV contribution from this planet at each epoch.
-            for (i, epoch) in enumerate(gaia_table_rv.epoch)
-                sol = orbitsolve(orbit, epoch)
-                rv_model[i] += radvel(sol, planet_mass_msol)/1e3 # barycentric rv in km/s
+        end
+        if rv_use_cache
+            @inbounds for i_planet in 1:n_planets
+                planet_mass_msol = θ_system.planets[i_planet].mass*Octofitter.mjup2msol
+                planet_mass_msol == 0.0 && continue
+                sols = planet_sols_cache[i_planet]
+                for i in 1:n_rv_ep
+                    sol = sols[n_hip_cache + i]
+                    rv_model[i] += radvel(sol, planet_mass_msol)/1e3
+                end
+            end
+        else
+            for (i_planet, (orbit, θ_planet)) in enumerate(zip(orbits, θ_system.planets))
+                planet_mass_msol = θ_planet.mass*Octofitter.mjup2msol
+                if planet_mass_msol == 0.0
+                    continue
+                end
+                # Accumulate the RV contribution from this planet at each epoch.
+                for (i, epoch) in enumerate(gaia_table_rv.epoch)
+                    sol = orbitsolve(orbit, epoch)
+                    rv_model[i] += radvel(sol, planet_mass_msol)/1e3 # barycentric rv in km/s
+                end
             end
         end
 
         # Calculate sample variance (Eq. A2 of Chance et al. 2022)
-        rv_mean = mean(rv_model)
-        sample_variance = sum((rv_model .- rv_mean).^2) / (length(rv_model) - 1)
+        rv_sum = zero(T)
+        @inbounds for i in 1:n_rv_ep
+            rv_sum += rv_model[i]
+        end
+        rv_mean = rv_sum / n_rv_ep
+        rv_sumsq = zero(T)
+        @inbounds for i in 1:n_rv_ep
+            d = rv_model[i] - rv_mean
+            rv_sumsq += d * d
+        end
+        sample_variance = rv_sumsq / (n_rv_ep - 1)
 
         N_rv = like.catalog.rv_nb_transits
         rv_dof = N_rv - 1
@@ -2071,7 +2442,7 @@ function Octofitter.generate_from_params(like::G23HObs, ctx::SystemObservationCo
     new_table = Table(merge(table_cols, (; pm = new_pm, σ_pm = new_σ_pm)))
 
     # ── 9. Construct new G23HObs ──
-    return G23HObs{
+    obj = G23HObs{
         typeof(new_table),
         typeof(new_hip_table),
         typeof(like.gaia_table),
@@ -2090,7 +2461,15 @@ function Octofitter.generate_from_params(like::G23HObs, ctx::SystemObservationCo
         like.A_prepared_5_dr3,
         like.include_iad,
         like.ueva_mode,
+        Ref{Matrix{Float64}}(zeros(0, 0)),
+        Ref{NTuple{4, Float64}}((0.0, 0.0, 0.0, 0.0)),
+        Ref{Bool}(false),
     )
+    # Note: the caches derive from hip_table.{sres,res}, which may differ in
+    # the newly generated table — recompute eagerly for the new object.
+    _ensure_pinv_5_hip!(obj)
+    _ensure_hip_x_const!(obj)
+    return obj
 end
 
 export G23HObs

--- a/src/likelihoods/g23h.jl
+++ b/src/likelihoods/g23h.jl
@@ -1595,18 +1595,65 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
     if :rv_dr3 ∈ like.table.kind
         σ_rv_per_transit = θ_obs.σ_rv_per_transit  # per-transit RV uncertainty in km/s
 
-        # Simulate RV measurements at Gaia epochs
+        # Simulate RV measurements at Gaia epochs.
+        #
+        # The Gaia DR3 RVS measurement is the *flux-weighted blend* of all sources
+        # whose spectra fall within the RVS extraction window — not the primary's
+        # reflex velocity alone.  For a single luminous companion in the BINARYS
+        # regime the blended-frame primary-component reflex amplitude is
+        #
+        #     v_blend = v_pri · (1 − β/B)     ≡ v_pri · (B − β)/B
+        #
+        # where β = f/(1+f) is the light fraction and B = M_comp/M_total.  In the
+        # dark-companion limit (f → 0) this collapses to v_pri, so single-planet
+        # exoplanet fits are bit-identical to the previous code path.  For
+        # near-equal-mass-equal-flux binaries (β ≈ B) the blended signal vanishes,
+        # and the correction is essential to avoid the model needing a phantom
+        # inner companion to absorb a non-existent RV reflex.
+        #
+        # Multi-companion form (with all per-planet light fractions f_k_eff already
+        # tapered for the RVS PSF below):
+        #
+        #     v_blend(t) = Σ_k radvel(sol_k(t), m_k) · (1 − f_k_eff·M_pri/M_k)
+        #                 / (1 + Σ_l f_l_eff)
+        #
+        # Per-epoch RVS spectral-blending taper.  The RVS slitless spectrograph
+        # has an across-scan window of ~1.77″ (10 × 0.177″ pixels; Cropper+2018,
+        # Sartoretti+2018) plus a small AC PSF, giving an effective Gaussian
+        # taper α(ρ) ≈ exp(−(ρ/σ_RVS)²) with σ_RVS ≈ 1.1″.  α(1″) ≈ 0.44, α(2″)
+        # ≈ 0.04, α(3″) ≈ 6×10⁻⁴ — consistent with the DR3 RV pipeline treating
+        # pairs <1.6″ as severely blended and >3″ as clean.
+        σ_RVS_arcsec = 1.1
+        M_pri = θ_system.M_pri
+
         rv_model = zeros(T, length(gaia_table_rv.epoch))
 
-        for (i_planet, (orbit, θ_planet)) in enumerate(zip(orbits, θ_system.planets))
-            planet_mass_msol = θ_planet.mass*Octofitter.mjup2msol
-            if planet_mass_msol == 0.0
-                continue
+        n_planets = length(orbits)
+        for (i, epoch) in enumerate(gaia_table_rv.epoch)
+            # Per-planet orbit solution and projected separation at this epoch
+            sols    = ntuple(k -> orbitsolve(orbits[k], epoch), n_planets)
+            ρ_arcs  = ntuple(k -> projectedseparation(sols[k]) / 1000, n_planets)  # mas → ″
+
+            # Per-planet RVS-effective light fraction (un-gated MIST Hp value
+            # tapered by the RVS spectral-blending kernel; Hp ≈ RVS color for MS
+            # stars to within a few percent — adequate for the blending factor).
+            f_eff = ntuple(n_planets) do k
+                f_hip_k = θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip :
+                          θ_obs.fluxratio_hip[k]
+                f_hip_k * exp(-(ρ_arcs[k] / σ_RVS_arcsec)^2)
             end
-            # Accumulate the RV contribution from this planet at each epoch.
-            for (i, epoch) in enumerate(gaia_table_rv.epoch)
-                sol = orbitsolve(orbit, epoch)
-                rv_model[i] += radvel(sol, planet_mass_msol)/1e3 # barycentric rv in km/s
+            f_total = one(T) + sum(f_eff)
+
+            for k in 1:n_planets
+                planet_mass_msol = θ_system.planets[k].mass * Octofitter.mjup2msol
+                planet_mass_msol == 0.0 && continue
+                v_pri_k = radvel(sols[k], planet_mass_msol) / 1e3   # km/s
+                # Blending: companion's anti-correlated velocity is
+                # v_sec_k = −(M_pri / m_k) · v_pri_k, so the per-companion
+                # blended contribution to the primary's spectroscopic frame is
+                # (1 − f_eff_k · M_pri/m_k) · v_pri_k / f_total.
+                blend_k = (one(T) - f_eff[k] * M_pri / planet_mass_msol) / f_total
+                rv_model[i] += blend_k * v_pri_k
             end
         end
 

--- a/src/likelihoods/g23h.jl
+++ b/src/likelihoods/g23h.jl
@@ -1669,65 +1669,18 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
     if :rv_dr3 ∈ like.table.kind
         σ_rv_per_transit = θ_obs.σ_rv_per_transit  # per-transit RV uncertainty in km/s
 
-        # Simulate RV measurements at Gaia epochs.
-        #
-        # The Gaia DR3 RVS measurement is the *flux-weighted blend* of all sources
-        # whose spectra fall within the RVS extraction window — not the primary's
-        # reflex velocity alone.  For a single luminous companion in the BINARYS
-        # regime the blended-frame primary-component reflex amplitude is
-        #
-        #     v_blend = v_pri · (1 − β/B)     ≡ v_pri · (B − β)/B
-        #
-        # where β = f/(1+f) is the light fraction and B = M_comp/M_total.  In the
-        # dark-companion limit (f → 0) this collapses to v_pri, so single-planet
-        # exoplanet fits are bit-identical to the previous code path.  For
-        # near-equal-mass-equal-flux binaries (β ≈ B) the blended signal vanishes,
-        # and the correction is essential to avoid the model needing a phantom
-        # inner companion to absorb a non-existent RV reflex.
-        #
-        # Multi-companion form (with all per-planet light fractions f_k_eff already
-        # tapered for the RVS PSF below):
-        #
-        #     v_blend(t) = Σ_k radvel(sol_k(t), m_k) · (1 − f_k_eff·M_pri/M_k)
-        #                 / (1 + Σ_l f_l_eff)
-        #
-        # Per-epoch RVS spectral-blending taper.  The RVS slitless spectrograph
-        # has an across-scan window of ~1.77″ (10 × 0.177″ pixels; Cropper+2018,
-        # Sartoretti+2018) plus a small AC PSF, giving an effective Gaussian
-        # taper α(ρ) ≈ exp(−(ρ/σ_RVS)²) with σ_RVS ≈ 1.1″.  α(1″) ≈ 0.44, α(2″)
-        # ≈ 0.04, α(3″) ≈ 6×10⁻⁴ — consistent with the DR3 RV pipeline treating
-        # pairs <1.6″ as severely blended and >3″ as clean.
-        σ_RVS_arcsec = 1.1
-        M_pri = θ_system.M_pri
-
+        # Simulate RV measurements at Gaia epochs
         rv_model = zeros(T, length(gaia_table_rv.epoch))
 
-        n_planets = length(orbits)
-        for (i, epoch) in enumerate(gaia_table_rv.epoch)
-            # Per-planet orbit solution and projected separation at this epoch
-            sols    = ntuple(k -> orbitsolve(orbits[k], epoch), n_planets)
-            ρ_arcs  = ntuple(k -> projectedseparation(sols[k]) / 1000, n_planets)  # mas → ″
-
-            # Per-planet RVS-effective light fraction (un-gated MIST Hp value
-            # tapered by the RVS spectral-blending kernel; Hp ≈ RVS color for MS
-            # stars to within a few percent — adequate for the blending factor).
-            f_eff = ntuple(n_planets) do k
-                f_hip_k = θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip :
-                          θ_obs.fluxratio_hip[k]
-                f_hip_k * exp(-(ρ_arcs[k] / σ_RVS_arcsec)^2)
+        for (i_planet, (orbit, θ_planet)) in enumerate(zip(orbits, θ_system.planets))
+            planet_mass_msol = θ_planet.mass*Octofitter.mjup2msol
+            if planet_mass_msol == 0.0
+                continue
             end
-            f_total = one(T) + sum(f_eff)
-
-            for k in 1:n_planets
-                planet_mass_msol = θ_system.planets[k].mass * Octofitter.mjup2msol
-                planet_mass_msol == 0.0 && continue
-                v_pri_k = radvel(sols[k], planet_mass_msol) / 1e3   # km/s
-                # Blending: companion's anti-correlated velocity is
-                # v_sec_k = −(M_pri / m_k) · v_pri_k, so the per-companion
-                # blended contribution to the primary's spectroscopic frame is
-                # (1 − f_eff_k · M_pri/m_k) · v_pri_k / f_total.
-                blend_k = (one(T) - f_eff[k] * M_pri / planet_mass_msol) / f_total
-                rv_model[i] += blend_k * v_pri_k
+            # Accumulate the RV contribution from this planet at each epoch.
+            for (i, epoch) in enumerate(gaia_table_rv.epoch)
+                sol = orbitsolve(orbit, epoch)
+                rv_model[i] += radvel(sol, planet_mass_msol)/1e3 # barycentric rv in km/s
             end
         end
 

--- a/src/likelihoods/g23h.jl
+++ b/src/likelihoods/g23h.jl
@@ -698,8 +698,9 @@ function ln_like(like::G23HObs, ctx::SystemObservationContext)
             ll = convert(T,-Inf)
         else
 
-            (; μ_h, μ_hg, μ_dr2, μ_dr32, μ_dr3, UEVA_model, UEVA_unc, μ_1_3, n_dr3, n_dr2) = sim       
+            (; μ_h, μ_hg, μ_dr2, μ_dr32, μ_dr3, UEVA_model, UEVA_unc, μ_1_3, n_dr3, n_dr2) = sim
             (;deflation_factor_dr3) = sim
+            (;hip_bias_pm_sq) = sim
             # Check if we have absolute orbits
             absolute_orbits = false
             for orbit in orbits
@@ -990,6 +991,31 @@ function ln_like(like::G23HObs, ctx::SystemObservationContext)
                     Σ_h = Σ_h * hip_inflate_sq
                 end
             end
+
+            # BINARYS epistemic uncertainty on the catalog-bias correction.
+            # The model's predicted bias (Δpmra_h, Δpmdec_h) is the BINARYS
+            # photocentre modulation absorbed by the published Hipparcos
+            # catalog 5-param fit; it's correct only to the extent that our
+            # likelihood matches what the Hipparcos pipeline actually did.
+            # Known approximations:
+            #   * H1+H2 composite catalog point modelled with a single-IAD
+            #     basis matrix (one reduction's scan angles, weights, and
+            #     parallax factors);
+            #   * Hp-band MLR systematics in the per-companion fluxratio_hip
+            #     prediction, especially across the tip of the M-dwarf MS;
+            #   * partial resolution gate (Gaussian taper anchored to the
+            #     grating step rather than empirical detection efficiency).
+            # We absorb residual model error by adding ε² · |Δpm_h|² to Σ_h
+            # isotropically.  At the dark-companion / single-star limit the
+            # bias is zero and this is a no-op; at high f / sep ≈ s the bias
+            # grows and the catalog likelihood loosens by a regime-
+            # appropriate amount.  ε_binarys is the relative trust on the
+            # bias prediction (0.3 ≡ 30%, conservative first-pass value).
+            ε_binarys = T(0.3)
+            if !isnothing(dist_hip) && hip_bias_pm_sq > zero(T)
+                Σ_h = Σ_h + (ε_binarys^2 * hip_bias_pm_sq) * SMatrix{2, 2, T, 4}(I)
+            end
+
 
             # Apply deflation adjustment to DR32 covariance
             Σ_dr32 = SMatrix{2, 2, T, 4}(Σ_dr32 .+ ΔΣ_dr32)
@@ -1343,6 +1369,11 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
 
     ################################
     # Hipparcos
+    # Track |bias|² in PM space for the catalog-likelihood epistemic inflation
+    # downstream — see the ε_binarys block in ln_like.  Initialised here so the
+    # value flows through both branches of the if/else below into the return
+    # named tuple.
+    hip_bias_pm_sq = zero(T)
     if isnothing(like.catalog.dist_hip)
         # type stable since dist_hip is part of the likelihood type parameters
         # ie. we statically know which of these branches will be taken.
@@ -1388,6 +1419,11 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
             out = fit_5param_prepared(like.A_prepared_5_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, 0.0, like.hip_table.sres)
         end
         Δα_h, Δδ_h, Δpmra_h, Δpmdec_h = out.parameters
+        # Track magnitude of the BINARYS-predicted PM bias for the catalog-
+        # likelihood epistemic inflation downstream.  Σ_h compares against the
+        # Hipparcos catalog PMs (`dist_hip` is in mas/yr — see line 174), so
+        # the relevant bias components are Δpmra_h and Δpmdec_h.
+        hip_bias_pm_sq = Δpmra_h^2 + Δpmdec_h^2
         α_h₀, δ_h₀, pmra_h₀, pmdec_h₀ = propagate_astrom(orbits, like.catalog.epoch_ra_hip_mjd, like.catalog.epoch_dec_hip_mjd)
         μ_h = @SVector [pmra_h₀ + Δpmra_h, pmdec_h₀ + Δpmdec_h]
 
@@ -1740,6 +1776,11 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
         μ_dr32,
         μ_dr3,
         μ = (@SVector [μ_h[1],μ_h[2],μ_hg[1],μ_hg[2],μ_dr2[1],μ_dr2[2],μ_dr32[1],μ_dr32[2],μ_dr3[1],μ_dr3[2],UEVA_model,sample_variance]),
+
+        # Magnitude (squared) of the BINARYS-predicted PM bias on the
+        # Hipparcos catalog point.  Consumed by the ε_binarys epistemic
+        # inflation in ln_like.  Zero when no Hipparcos data are present.
+        hip_bias_pm_sq,
 
         n_dr3 = iend_dr3 - istart_dr3 + 1,
         n_dr2 = iend_dr2 - istart_dr2 + 1,

--- a/src/likelihoods/g23h.jl
+++ b/src/likelihoods/g23h.jl
@@ -678,7 +678,13 @@ function ln_like(like::G23HObs, ctx::SystemObservationContext)
         Δδ_mas_dr2 = @alloc(T, iend_dr2-istart_dr2+1); fill!(Δδ_mas_dr2, 0)
         Δα_mas_dr3 = @alloc(T, iend_dr3-istart_dr3+1); fill!(Δα_mas_dr3, 0)
         Δδ_mas_dr3 = @alloc(T, iend_dr3-istart_dr3+1); fill!(Δδ_mas_dr3, 0)
-        buffers = (;iad_resid, Δα_mas_hip, Δδ_mas_hip, Δα_mas_dr2, Δδ_mas_dr2, Δα_mas_dr3, Δδ_mas_dr3)
+        # σ-inflation buffer for the BINARYS first-harmonic correction
+        # (Leclerc et al. 2023, Eq. 15). Initialised to 1 (no inflation);
+        # populated in simulate! per transit from the *combined* multi-companion
+        # modulated signal. Used as the noise-model multiplier in the IAD-residual
+        # likelihood below — must NOT be used in the catalog-bias LSQ in simulate!.
+        σ_inflation_hip = @alloc(T, size(like.hip_table,1)); fill!(σ_inflation_hip, 1)
+        buffers = (;iad_resid, Δα_mas_hip, Δδ_mas_hip, σ_inflation_hip, Δα_mas_dr2, Δδ_mas_dr2, Δα_mas_dr3, Δδ_mas_dr3)
 
         sim = simulate!(buffers, like, θ_system, θ_obs, orbits, orbit_solutions, orbit_solutions_i_epoch_start) 
 
@@ -808,7 +814,13 @@ function ln_like(like::G23HObs, ctx::SystemObservationContext)
                         continue
                     end
                     (;hip_iad_jitter) = θ_obs
-                    ll += logpdf(Normal(0, hypot(like.hip_table.sres_renorm[i], hip_iad_jitter) ), iad_resid[i])
+                    # Inflate per-transit residual σ by the BINARYS first-harmonic
+                    # factor (Leclerc et al. 2023, Eq. 15). σ_inflation_hip[i] = 1
+                    # in the unresolved limit and grows where the binary modulation
+                    # reduces the signal amplitude — the IAD residual noise scales
+                    # the same way.
+                    σ_iad = hypot(like.hip_table.sres_renorm[i] * σ_inflation_hip[i], hip_iad_jitter)
+                    ll += logpdf(Normal(0, σ_iad), iad_resid[i])
                 end
             end
 
@@ -1075,8 +1087,9 @@ function simulate(like::G23HObs, θ_system, θ_obs, orbits, orbit_solutions, orb
     Δδ_mas_dr2 = zeros(iend_dr2-istart_dr2+1); fill!(Δδ_mas_dr2, 0)
     Δα_mas_dr3 = zeros(iend_dr3-istart_dr3+1); fill!(Δα_mas_dr3, 0)
     Δδ_mas_dr3 = zeros(iend_dr3-istart_dr3+1); fill!(Δδ_mas_dr3, 0)
+    σ_inflation_hip = ones(size(like.hip_table,1))
 
-    buffers = (;iad_resid, Δα_mas_hip, Δδ_mas_hip, Δα_mas_dr2, Δδ_mas_dr2, Δα_mas_dr3, Δδ_mas_dr3)
+    buffers = (;iad_resid, Δα_mas_hip, Δδ_mas_hip, σ_inflation_hip, Δα_mas_dr2, Δδ_mas_dr2, Δα_mas_dr3, Δδ_mas_dr3)
 
     out = simulate!(buffers, like, θ_system, θ_obs, orbits, orbit_solutions, orbit_solutions_i_epoch_start) 
 
@@ -1085,7 +1098,7 @@ end
 
 function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solutions, orbit_solutions_i_epoch_start) 
 
-    (;Δα_mas_hip, Δδ_mas_hip, Δα_mas_dr2, Δδ_mas_dr2, Δα_mas_dr3, Δδ_mas_dr3, iad_resid, ) = buffers
+    (;Δα_mas_hip, Δδ_mas_hip, σ_inflation_hip, Δα_mas_dr2, Δδ_mas_dr2, Δα_mas_dr3, Δδ_mas_dr3, iad_resid, ) = buffers
 
 
     T = _system_number_type(θ_system)
@@ -1299,38 +1312,42 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
     else
 
 
-        # Per-transit σ-inflation buffer for the BINARYS first-harmonic correction
-        # (Leclerc et al. 2023, Eq. 15). Initialised to 1 and accumulated
-        # multiplicatively per (luminous) planet; for non-luminous companions
-        # f_σ = 1 so it stays unchanged.
+        # σ_inflation_hip comes from the caller's buffer; reset it to 1 at the
+        # start of this evaluation. It will be populated *jointly* across all
+        # companions in a single call to `_simulate_skypath_hippacentre_combined!`
+        # below — multiplicative per-companion accumulation is wrong because the
+        # multi-source modulated signal is not the sum of per-companion signals.
         n_hip = length(like.hip_table.epoch)
-        σ_inflation_hip = ones(T, n_hip)
+        fill!(σ_inflation_hip, one(T))
 
-        for (i_planet,(orbit, θ_planet)) in enumerate(zip(orbits, θ_system.planets))
-            planet_mass_msol = θ_planet.mass*Octofitter.mjup2msol
-            if planet_mass_msol == 0.0
-                continue
-            end
-            # Hp-band per-companion flux ratio (M_Hp-derived). Required: this
-            # branch always uses BINARYS, which requires the Hp light fraction.
-            fluxratio_hip = θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip :
-                            θ_obs.fluxratio_hip[i_planet]
-            _simulate_skypath_perturbations!(
-                Δα_mas_hip, Δδ_mas_hip,
-                like.hip_table, orbit,
-                planet_mass_msol, fluxratio_hip,
-                orbit_solutions[i_planet],
-                -1, T;
-                grid_step_arcsec = HIPPARCOS_GRID_STEP_ARCSEC,
-                σ_inflation = σ_inflation_hip,
-            )
+        n_planets = length(orbits)
+        planet_masses_msol_hip = ntuple(i_planet -> θ_system.planets[i_planet].mass * Octofitter.mjup2msol, n_planets)
+        # Companions with mass = 0 contribute nothing — zero out their flux ratio so
+        # they fall out of both the modulated-signal sum and the host-reflex sum.
+        flux_ratios_hip = ntuple(n_planets) do i_planet
+            planet_masses_msol_hip[i_planet] == 0.0 ? zero(T) :
+                (θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip : θ_obs.fluxratio_hip[i_planet])
         end
-        # Inflate per-transit σ_residual by the BINARYS first-harmonic factor before LSQ.
-        sres_inflated = like.hip_table.sres .* σ_inflation_hip
+        # G23H pipeline calls per-planet `orbit_solutions[i_planet]` with start index −1
+        orbit_sol_starts_hip = ntuple(_ -> -1, n_planets)
+
+        _simulate_skypath_hippacentre_combined!(
+            Δα_mas_hip, Δδ_mas_hip, σ_inflation_hip,
+            like.hip_table,
+            orbits, planet_masses_msol_hip, flux_ratios_hip,
+            orbit_solutions, orbit_sol_starts_hip, T,
+            HIPPARCOS_GRID_STEP_ARCSEC,
+        )
+
+        # NB: extract the catalog 5-parameter bias with the *uninflated* σ — the
+        # Hipparcos pipeline that produced the catalog used point-source σ, so to
+        # reproduce the bias it absorbed we must weight the LSQ the same way.
+        # σ_inflation_hip is propagated separately into the IAD-residual likelihood
+        # (`σ_iad = hypot(sres_renorm * σ_inflation_hip, hip_iad_jitter)` below).
         if like.include_iad
-            out = fit_5param_prepared(like.A_prepared_5_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, like.hip_table.res, sres_inflated)
+            out = fit_5param_prepared(like.A_prepared_5_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, like.hip_table.res, like.hip_table.sres)
         else
-            out = fit_5param_prepared(like.A_prepared_5_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, 0.0, sres_inflated)
+            out = fit_5param_prepared(like.A_prepared_5_hip, like.hip_table, Δα_mas_hip, Δδ_mas_hip, 0.0, like.hip_table.sres)
         end
         Δα_h, Δδ_h, Δpmra_h, Δpmdec_h = out.parameters
         α_h₀, δ_h₀, pmra_h₀, pmdec_h₀ = propagate_astrom(orbits, like.catalog.epoch_ra_hip_mjd, like.catalog.epoch_dec_hip_mjd)
@@ -1787,24 +1804,21 @@ function Octofitter.generate_from_params(like::G23HObs, ctx::SystemObservationCo
         Δα_hip = zeros(n_hip)
         Δδ_hip = zeros(n_hip)
         σ_inflation_hip = ones(n_hip)
-        for (i_planet, (orbit, θ_planet)) in enumerate(zip(orbits, θ_system.planets))
-            planet_mass_msol = θ_planet.mass * Octofitter.mjup2msol
-            if planet_mass_msol == 0.0
-                continue
-            end
-            # Hp-band per-companion flux ratio: required for the BINARYS Hipparcos branch.
-            fluxratio_hip = θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip :
-                            θ_obs.fluxratio_hip[i_planet]
-            _simulate_skypath_perturbations!(
-                Δα_hip, Δδ_hip,
-                like.hip_table, orbit,
-                planet_mass_msol, fluxratio_hip,
-                orbit_solutions[i_planet],
-                -1, Float64;
-                grid_step_arcsec = HIPPARCOS_GRID_STEP_ARCSEC,
-                σ_inflation = σ_inflation_hip,
-            )
+        n_planets = length(orbits)
+        planet_masses_msol = ntuple(i_planet -> θ_system.planets[i_planet].mass * Octofitter.mjup2msol, n_planets)
+        # Companions with mass = 0 contribute nothing — zero out their flux ratio.
+        flux_ratios_hip = ntuple(n_planets) do i_planet
+            planet_masses_msol[i_planet] == 0.0 ? 0.0 :
+                (θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip : θ_obs.fluxratio_hip[i_planet])
         end
+        orbit_sol_starts = ntuple(_ -> -1, n_planets)
+        _simulate_skypath_hippacentre_combined!(
+            Δα_hip, Δδ_hip, σ_inflation_hip,
+            like.hip_table,
+            orbits, planet_masses_msol, flux_ratios_hip,
+            orbit_solutions, orbit_sol_starts, Float64,
+            HIPPARCOS_GRID_STEP_ARCSEC,
+        )
 
         # Project perturbation along scan direction
         b_hip = zeros(n_hip)

--- a/src/likelihoods/g23h.jl
+++ b/src/likelihoods/g23h.jl
@@ -456,7 +456,11 @@ function G23HObs(;
             σ_AL ~ truncated(Normal(catalog.sig_AL, catalog.sig_AL_sigma), lower=eps(), upper=10.0)
             σ_att ~ truncated(Normal(catalog.sig_att_radec, catalog.sig_att_radec_sigma), lower=eps(), upper=10.0)
             σ_calib ~ truncated(Normal(catalog.sig_cal, catalog.sig_cal_sigma), lower=eps(), upper=10.0)
+            # G-band flux ratio (used by Gaia DR2/DR3 photocentre branch).
             fluxratio = hasproperty(sys, :fluxratio) ? sys.fluxratio : 0.0
+            # Hp-band flux ratio (required by the BINARYS Hipparcos photocentre branch).
+            # Hard cut: must be supplied at the system level. No fallback.
+            fluxratio_hip = sys.fluxratio_hip
         end
 
         if(len_epochs) < astrometric_matched_transits_dr3

--- a/src/likelihoods/g23h.jl
+++ b/src/likelihoods/g23h.jl
@@ -681,8 +681,14 @@ function ln_like(like::G23HObs, ctx::SystemObservationContext)
         # σ-inflation buffer for the BINARYS first-harmonic correction
         # (Leclerc et al. 2023, Eq. 15). Initialised to 1 (no inflation);
         # populated in simulate! per transit from the *combined* multi-companion
-        # modulated signal. Used as the noise-model multiplier in the IAD-residual
-        # likelihood below — must NOT be used in the catalog-bias LSQ in simulate!.
+        # modulated signal. Consumed in two places: (a) the IAD-residual
+        # likelihood when include_iad=true, scaling the per-transit residual
+        # σ; (b) the catalog covariance Σ_h below, scaling it by the
+        # transit-averaged f_σ² to reflect binary-induced uncertainty
+        # inflation on the published Hipparcos catalog point. Must NOT be
+        # used in the catalog-bias LSQ inside simulate!, because that LSQ
+        # reproduces the *catalog construction* under the Hipparcos
+        # pipeline's point-source σ.
         σ_inflation_hip = @alloc(T, size(like.hip_table,1)); fill!(σ_inflation_hip, 1)
         buffers = (;iad_resid, Δα_mas_hip, Δδ_mas_hip, σ_inflation_hip, Δα_mas_dr2, Δδ_mas_dr2, Δα_mas_dr3, Δδ_mas_dr3)
 
@@ -953,6 +959,38 @@ function ln_like(like::G23HObs, ctx::SystemObservationContext)
             Σ_h = SMatrix{2, 2, T, 4}(Σ_h)
             Σ_hg = SMatrix{2, 2, T, 4}(Σ_hg)
             Σ_dr2 = SMatrix{2, 2, T, 4}(Σ_dr2)
+
+            # BINARYS f_σ inflation of the Hipparcos catalog covariance.  In
+            # the include_iad=false path the σ_inflation_hip buffer (the
+            # combined first-harmonic amplitude reduction from
+            # `_simulate_skypath_hippacentre_combined!`, Leclerc 2023 Eq. 15
+            # generalised) is otherwise dormant — the catalog 5-param fit at
+            # the Hipparcos pipeline used point-source σ, so the LSQ that
+            # reproduces the catalog bias must too, but the *uncertainty* on
+            # the catalog point itself should reflect the binary-induced
+            # increase in per-transit noise.  Multiply Σ_h by the
+            # transit-averaged f_σ² so that the catalog-likelihood
+            # covariance inflates regime-appropriately for luminous-binary
+            # configurations.  In the dark-companion / single-star /
+            # wide-resolved limit f_σ → 1 and this is a no-op.  Σ_hg is left
+            # uninflated for v1 (the long-baseline HG covariance has a Gaia
+            # endpoint as well, so the right multiplier would be < f_σ²; we
+            # take the conservative course and let HG self-calibrate via
+            # HGCA's renormalisation).
+            if !isnothing(dist_hip) && size(like.hip_table, 1) > 0
+                n_used_hip = 0
+                sumsq_inflate = zero(T)
+                for i in eachindex(σ_inflation_hip)
+                    like.hip_table.reject[i] && continue
+                    n_used_hip += 1
+                    sumsq_inflate += σ_inflation_hip[i]^2
+                end
+                if n_used_hip > 0
+                    hip_inflate_sq = sumsq_inflate / n_used_hip
+                    Σ_h = Σ_h * hip_inflate_sq
+                end
+            end
+
             # Apply deflation adjustment to DR32 covariance
             Σ_dr32 = SMatrix{2, 2, T, 4}(Σ_dr32 .+ ΔΣ_dr32)
             # Σ_dr32 = SMatrix{2, 2, T, 4}(Σ_dr32)

--- a/src/likelihoods/g23h.jl
+++ b/src/likelihoods/g23h.jl
@@ -74,6 +74,12 @@ struct G23HObs{TTable,TTableH,TTableG,TCat,THip} <: AbstractObs
     _hip_x_const_initialised::Base.RefValue{Bool}
 end
 
+# Diagnostic hook (off by default; zero hot-path cost when nothing).  When set to
+# a Vector, ln_like pushes a NamedTuple of the per-channel astrometry residuals
+# (catalog vs model μ and marginal σ) for the PM/UEVA MvNormal block — used to
+# numerically verify simulator/likelihood agreement (pulls ~ N(0,1) at truth).
+const _G23H_DEBUG_PULLS = Ref{Any}(nothing)
+
 # G23H short-circuits on mass == 0 everywhere it consumes per-planet orbit
 # solutions (DR2/DR3 skypath perturbations, the Hippacentre combined loop,
 # and the Gaia RV simulation all `continue` on zero-mass companions), so
@@ -188,6 +194,20 @@ function G23HObs(;
         # this mitigates overfitting.
         hip_table.res .+= 0.140
         hip_table.sres_renorm .= hypot.(hip_table.sres_renorm, 2.25)
+
+        # The HipparcosIADLikelihood constructor baked res-derived columns
+        # (α✱ₐ, δₐ, α✱ₘ, δₘ, proj_meas_alongscan) BEFORE this in-place
+        # recalibration, so recompute them here — otherwise the +0.140 mas
+        # shift never reaches the IAD channel, which reads
+        # proj_meas_alongscan (audit 2026-07-02).
+        hip_table.α✱ₐ .= hip_table.res .* hip_table.cosϕ .+ hip_table.Δα✱
+        hip_table.δₐ  .= hip_table.res .* hip_table.sinϕ .+ hip_table.Δδ
+        for i in eachindex(hip_table.α✱ₘ)
+            hip_table.α✱ₘ[i] .= [-1, 1] .* hip_table.sinϕ[i] .+ hip_table.α✱ₐ[i]
+            hip_table.δₘ[i]  .= [1, -1] .* hip_table.cosϕ[i] .+ hip_table.δₐ[i]
+        end
+        hip_table.proj_meas_alongscan .= hip_table.res .+
+            hip_table.Δα✱ .* hip_table.cosϕ .+ hip_table.Δδ .* hip_table.sinϕ
 
         # Precompute MvNormal distributions for correlation between ra and dec
         # Hipparcos epoch
@@ -316,6 +336,17 @@ function G23HObs(;
     end
     gaia_table = Table(map(dat->dat[], gaia_table))
 
+    # Trim to the DR3 window: GOST forecasts can extend well past the DR3 data
+    # span (often to 2018+). Epochs after meta_gaia_DR3.stop_mjd can never
+    # contribute to any modeled channel (the DR2/DR3 window slices exclude
+    # them), but left in the table they consume transit_priorities selection
+    # slots: chi_squared_astro is then summed over only the in-window survivors
+    # while its UEVA normalization uses the catalog astrometric_matched_transits
+    # count — understating the predicted companion-induced UEVA excess by ~the
+    # out-of-window fraction (median ~29% over the Hipparcos sample). Single
+    # stars are unaffected (zero signal either way); companion hosts need a
+    # spuriously larger companion to reproduce the observed RUWE/UEVA.
+    gaia_table = gaia_table[vec(gaia_table.epoch) .<= meta_gaia_DR3.stop_mjd]
 
     # Determine fraction of epochs in DR2 that overlap with DR3
 
@@ -504,7 +535,9 @@ function G23HObs(;
             # sample the epochs randomly once and fix them for all remaining sampling
             if freeze_epochs
                 transit_priorities = (randn(len_epochs)...,)
-                transits = partialsortperm(SVector(transit_priorities), 1:astrometric_matched_transits_dr3, rev=true)
+                # sort: downstream window logic (findfirst/findlast on gaia_table[transits,:].epoch)
+                # requires chronological order; partialsortperm returns priority order.
+                transits = sort(partialsortperm(SVector(transit_priorities), 1:astrometric_matched_transits_dr3, rev=true))
                 variables = vcat(variables, @variables begin
                     transit_priorities = $transit_priorities
                     transits = $transits
@@ -523,7 +556,10 @@ function G23HObs(;
                 # are the values with the highest values.
                 variables = vcat(variables, @variables begin
                     transit_priorities ~ MvNormal(zeros(len_epochs), I)
-                    transits = partialsortperm(SVector(transit_priorities), 1:$astrometric_matched_transits_dr3, rev=true)
+                    # sort: downstream window logic (findfirst/findlast on gaia_table[transits,:].epoch)
+                    # requires chronological order; partialsortperm returns priority order (unsorted
+                    # epochs collapse the DR2/DR3 windows onto each other: n_dr2≈n_dr3 → ρ_dr3_dr2≈1).
+                    transits = sort(partialsortperm(SVector(transit_priorities), 1:$astrometric_matched_transits_dr3, rev=true))
                 end)
             end
         end
@@ -557,6 +593,14 @@ function G23HObs(;
 
             n_rv = Int(catalog.rv_nb_transits)
             @info "Count of RV transits:" n_rv total_transits=len_epochs
+            if n_rv > len_epochs
+                # RV shortfall: catalog reports more RV transits than in-window
+                # GOST forecast epochs. All available epochs are used; the
+                # modeled sample variance stays unbiased (it is count-
+                # normalized, unlike the astrometric chi² sum) but samples the
+                # window more coarsely than Gaia did.
+                @warn "More Gaia RV transits than in-window GOST forecast epochs; modeling RV scatter with all available epochs." n_rv len_epochs
+            end
 
             # RV transits are modeled as a subset of the astrometric-used transits:
             # entirely-missed visits (e.g. gaps in Gaia coverage) are assumed missed
@@ -566,7 +610,7 @@ function G23HObs(;
             # (whenever n_rv ≤ astrometric_matched_transits_dr3).
             if n_rv > 0 && n_rv < len_epochs
                 rv_vars = @variables begin
-                    transits_rv = partialsortperm(SVector(transit_priorities), 1:$n_rv, rev=true)
+                    transits_rv = sort(partialsortperm(SVector(transit_priorities), 1:$n_rv, rev=true))
                 end
                 variables = vcat(variables, rv_vars)
             end
@@ -670,7 +714,13 @@ function _ensure_pinv_5_hip!(like::G23HObs)
     # are fixed at construction, so we can cache `Q = pinv(A/σ) ./ σ'` —
     # one matvec `Q · b_orig` then reproduces the weighted-LSQ x exactly.
     if isempty(like._pinv_5_hip[]) && !isempty(like.A_prepared_5_hip)
-        σ_hip = like.hip_table.sres
+        # sres ≤ 0 encodes scans the Hipparcos reduction REJECTED from its
+        # solution; give them zero weight (σ = Inf) so this catalog-reproduction
+        # LSQ matches what the catalog actually fit.  (A raw negative sres would
+        # sneak the scan back in at weight 1/|sres|, and sres == 0 would produce
+        # an Inf-weighted row.)  The IAD residual channel skips these rows
+        # separately (audit 2026-07-02).
+        σ_hip = map(s -> s > 0 ? float(s) : Inf, like.hip_table.sres)
         A = like.A_prepared_5_hip
         # A_scaled[i, j] = A[i, j] / σ[i] (row-wise scale).  Then
         # Q = pinv(A_scaled) is 5×n; weight back to x = Q·(b/σ) form by
@@ -1184,6 +1234,18 @@ function ln_like(like::G23HObs, ctx::SystemObservationContext)
             Σ_selected = @alloc(T, n_components, n_components)
             @inbounds for kj in 1:n_components, ki in 1:n_components
                 Σ_selected[ki, kj] = Σ_full[indices[ki], indices[kj]]
+            end
+
+            # Diagnostic capture (no-op unless _G23H_DEBUG_PULLS holds a Vector).
+            if _G23H_DEBUG_PULLS[] !== nothing
+                lbls = [component_flags[indices[k]] for k in 1:n_components]
+                cat  = [Float64(μ_catalog_selected[k]) for k in 1:n_components]
+                mod  = [Float64(μ_model_selected[k]) for k in 1:n_components]
+                sig  = [sqrt(Float64(Σ_selected[k,k])) for k in 1:n_components]
+                Σcap = [Float64(Σ_selected[ki,kj]) for ki in 1:n_components, kj in 1:n_components]
+                push!(_G23H_DEBUG_PULLS[],
+                      (; labels=lbls, catalog=cat, model=mod, sigma=sig,
+                         pull=(cat .- mod) ./ sig, Σ=Σcap))
             end
 
             # Compute likelihood
@@ -1954,8 +2016,15 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
     μ_1_3 = UEVA_Gaia^(1/3)
     UEVA_unc = σ_UEVA_single * μ_UEVA_single^(-2/3) / 3 # divide by 3 due to cube root transformation
 
-    # Calculate model-predicted UEVA from our fit
-    chi2_astro_scaled = out_dr3.chi_squared_astro * N_AL
+    # Calculate model-predicted UEVA from our fit.
+    # chi_squared_astro sums squared residuals over the transits actually
+    # modeled (the DR3 window slice), while the UEVA normalizations below
+    # assume N_FoV of them. The counts agree except in the GOST-shortfall
+    # case (fewer in-window forecast epochs than catalog matched transits,
+    # where `transits` falls back to all epochs); rescale so the predicted
+    # excess per companion stays consistent with the N_FoV normalization.
+    n_dr3_modeled = iend_dr3 - istart_dr3 + 1
+    chi2_astro_scaled = out_dr3.chi_squared_astro * N_AL * (N_FoV / n_dr3_modeled)
     UEVA_model_raw = (chi2_astro_scaled * σ_formal^2) / (N - gaia_n_dof)
 
     # For the UEVA likelihood, use cube-root transformation (Eq. 27, Sect 5.1.1)
@@ -2146,10 +2215,28 @@ function Octofitter.generate_from_params(like::G23HObs, ctx::SystemObservationCo
     if isnothing(sim)
         error("G23HObs simulate returned nothing during data generation (duplicate transit indices?)")
     end
-    (; μ_h, μ_hg, μ_dr2, μ_dr32, μ_dr3, UEVA_model, UEVA_unc, μ_1_3, sample_variance) = sim
+    (; μ_h, μ_hg, μ_dr2, μ_dr32, μ_dr3, UEVA_model, UEVA_unc, μ_1_3, sample_variance, n_dr2, n_dr3) = sim
 
     catalog = like.catalog
     has_hip = !isnothing(catalog.dist_hip)
+
+    # ── 0. HGCA nonlinear proper-motion correction ──
+    # `ln_like` adds catalog.nonlinear_dpmra/dpmdec to the model μ_hg (and 2× to
+    # μ_h) for absolute orbits when Hipparcos is present (see the "Apply nonlinear
+    # correction for absolute orbits" block above).  The simulated catalog PMs are
+    # built below from the bare μ returned by `simulate`, so without mirroring the
+    # correction here the synthetic data sits on a different convention than the
+    # likelihood's model — a phantom HG/Hip proper-motion anomaly of magnitude
+    # nonlinear_dpm at the true parameters.  Apply the identical correction so the
+    # forward simulator and the likelihood agree.
+    absolute_orbits = false
+    for orbit in orbits
+        absolute_orbits |= orbit isa AbsoluteVisual
+    end
+    if absolute_orbits && has_hip
+        μ_hg = μ_hg + @SVector [catalog.nonlinear_dpmra, catalog.nonlinear_dpmdec]
+        μ_h  = μ_h  + @SVector [2catalog.nonlinear_dpmra, 2catalog.nonlinear_dpmdec]
+    end
 
     # ── 1. UEVA / RUWE / EAN simulation and DR3 uncertainty inflation ──
     #
@@ -2235,15 +2322,70 @@ function Octofitter.generate_from_params(like::G23HObs, ctx::SystemObservationCo
         new_pm_hg = _draw_correlated_pm(μ_hg,
             catalog.pmra_hg_error[1], catalog.pmdec_hg_error[1], catalog.pmra_pmdec_hg[1])
     end
-    # DR2: use original errors (DR2 pipeline is different; we don't model its inflation)
-    new_pm_dr2 = _draw_correlated_pm(μ_dr2,
-        catalog.pmra_dr2_error[1], catalog.pmdec_dr2_error[1], catalog.pmra_pmdec_dr2[1])
-    # DR32: use inflated errors (DR3 position contribution inflated by companion)
-    new_pm_dr32 = _draw_correlated_pm(μ_dr32,
-        new_pmra_dr32_error, new_pmdec_dr32_error, catalog.pmra_pmdec_dr32[1])
-    # DR3: use inflated errors (companion degrades DR3 fit quality)
-    new_pm_dr3 = _draw_correlated_pm(μ_dr3,
-        new_pmra_dr3_error, new_pmdec_dr3_error, catalog.pmra_pmdec_dr3[1])
+    # DR2/DR32/DR3: draw from the SAME covariance structure ln_like will assemble
+    # at the truth parameters, otherwise the synthetic data violates the
+    # likelihood's correlation model.  ln_like (a) couples the DR2 and DR3 PMs
+    # with the cross block K = ρ·√Σ_dr2·√Σ_dr3' where ρ = √(n_dr2/n_dr3)
+    # (shared transits), (b) deflates Σ_dr3 by deflation_factor_dr3² recomputed
+    # at fit time from the *simulated* catalog, and (c) adds the deflation-driven
+    # ΔΣ_dr32 adjustment to Σ_dr32.  Independent draws leave the two conditional
+    # DR2/DR3 directions over-dispersed by 1/(1-ρ²) in whitened space — the fit
+    # reads the excess as astrometric acceleration → spurious decades-period
+    # companions.  Mirror ln_like exactly (verified by the joint-χ² MC test).
+    ρ_dr3_dr2 = sqrt(min(n_dr2, n_dr3) / max(n_dr2, n_dr3))
+    # deflation the fit will apply at truth: UEVA_Gaia reconstructed from the
+    # NEW catalog is max(σ_formal², new_UEVA) in both :RUWE and :EAN modes
+    # (the new_chi2_al / new_ean clamps above make the two expressions agree).
+    UEVA_Gaia_fit = max(σ_formal^2, new_UEVA)
+    deflation_truth = min(1.0, sqrt(μ_UEVA_single / UEVA_Gaia_fit))
+
+    c2 = catalog.pmra_pmdec_dr2[1] * catalog.pmra_dr2_error[1] * catalog.pmdec_dr2_error[1]
+    Σ_dr2_gen = @SArray [
+        catalog.pmra_dr2_error[1]^2 c2
+        c2 catalog.pmdec_dr2_error[1]^2
+    ]
+    c3 = catalog.pmra_pmdec_dr3[1] * new_pmra_dr3_error * new_pmdec_dr3_error
+    Σ_dr3_gen = (@SArray [
+        new_pmra_dr3_error^2 c3
+        c3 new_pmdec_dr3_error^2
+    ]) .* deflation_truth^2
+
+    if add_noise
+        K_gen = ρ_dr3_dr2 * sqrt(Σ_dr2_gen) * sqrt(Σ_dr3_gen)'
+        Σ_23 = SMatrix{4,4,Float64,16}([Σ_dr2_gen K_gen; K_gen' Σ_dr3_gen])
+        noise_23 = cholesky(Hermitian(Σ_23)).L * @SVector[randn(), randn(), randn(), randn()]
+        new_pm_dr2 = μ_dr2 .+ @SVector[noise_23[1], noise_23[2]]
+        new_pm_dr3 = μ_dr3 .+ @SVector[noise_23[3], noise_23[4]]
+    else
+        new_pm_dr2 = SVector{2,Float64}(μ_dr2)
+        new_pm_dr3 = SVector{2,Float64}(μ_dr3)
+    end
+
+    # DR32 with the fit-time ΔΣ_dr32 deflation adjustment (mirrors ln_like).
+    Σ_pos_dr3_gen = @SMatrix [
+        new_ra_error_central_dr3^2  catalog.ra_dec_corr_central_dr3*new_ra_error_central_dr3*new_dec_error_central_dr3
+        catalog.ra_dec_corr_central_dr3*new_ra_error_central_dr3*new_dec_error_central_dr3  new_dec_error_central_dr3^2
+    ]
+    Σ_cross_gen = @SMatrix [
+        ρ_dr3_dr2*new_ra_error_central_dr3*catalog.ra_error_central_dr2  ρ_dr3_dr2*catalog.ra_dec_corr_central_dr3*new_ra_error_central_dr3*catalog.dec_error_central_dr2
+        ρ_dr3_dr2*catalog.ra_dec_corr_central_dr2*new_dec_error_central_dr3*catalog.ra_error_central_dr2  ρ_dr3_dr2*new_dec_error_central_dr3*catalog.dec_error_central_dr2
+    ]
+    ΔΣ_pos_gen = (deflation_truth^2 - 1) * Σ_pos_dr3_gen - (deflation_truth - 1) * (Σ_cross_gen + Σ_cross_gen')
+    Δt_ra_gen = (catalog.epoch_ra_dr3_mjd - catalog.epoch_ra_dr2_mjd) / julian_year
+    Δt_dec_gen = (catalog.epoch_dec_dr3_mjd - catalog.epoch_dec_dr2_mjd) / julian_year
+    Tr_gen = @SMatrix [1/Δt_ra_gen 0.0; 0.0 1/Δt_dec_gen]
+    ΔΣ_dr32_gen = Tr_gen * ΔΣ_pos_gen * Tr_gen'
+    c32 = catalog.pmra_pmdec_dr32[1] * new_pmra_dr32_error * new_pmdec_dr32_error
+    Σ_dr32_gen = (@SArray [
+        new_pmra_dr32_error^2 c32
+        c32 new_pmdec_dr32_error^2
+    ]) + ΔΣ_dr32_gen
+    if add_noise
+        noise_32 = cholesky(Hermitian(Σ_dr32_gen)).L * @SVector[randn(), randn()]
+        new_pm_dr32 = μ_dr32 .+ noise_32
+    else
+        new_pm_dr32 = SVector{2,Float64}(μ_dr32)
+    end
 
     # ── 3. Hipparcos IAD residuals ──
     # The residuals capture the companion's curvature signal (non-linear sky path

--- a/src/likelihoods/g23h.jl
+++ b/src/likelihoods/g23h.jl
@@ -564,7 +564,10 @@ function G23HObs(;
             end
         end
 
-        if !isnothing(hip_like)
+        # The IAD nuisance parameters are only meaningful while the :iad_hip
+        # likelihood row exists (likeobj_from_epoch_subset strips them again
+        # if a subset later removes that row).
+        if !isnothing(hip_like) && :iad_hip ∈ table.kind
             variables_iad = @variables begin
                 hip_iad_jitter ~ LogUniform(0.001, 100)
                 iad_Δra     ~ Uniform(-1000, 1000)
@@ -671,14 +674,31 @@ function Octofitter.likeobj_from_epoch_subset(like::G23HObs, obs_inds)
         ueva_mode ) = like
 
     table = table[obs_inds,:]
+    # NB: test the POST-subset table (`table`), not `like.table` — the whole
+    # point is to react to rows the subset removed. (Previously checked the
+    # original table, so the dist_hip/dist_hg nulling could never fire.)
     if  (
-            :iad_hip ∉ like.table.kind &&
-            :ra_hip ∉ like.table.kind &&
-            :dec_hip ∉ like.table.kind &&
-            :ra_hg ∉ like.table.kind &&
-            :dec_hg ∉ like.table.kind
+            :iad_hip ∉ table.kind &&
+            :ra_hip ∉ table.kind &&
+            :dec_hip ∉ table.kind &&
+            :ra_hg ∉ table.kind &&
+            :dec_hg ∉ table.kind
         )
         catalog = (;catalog..., dist_hip = nothing, dist_hg=nothing)
+    end
+    # When the subset removes the :iad_hip row, the six IAD nuisance
+    # parameters (hip_iad_jitter, iad_Δra/Δdec/Δplx/Δpmra/Δpmdec) and their
+    # two derived quantities (iad_pmra/iad_pmdec) no longer touch the
+    # likelihood anywhere — they would be sampled as pure prior draws,
+    # inflating the model dimension by 6 for nothing. Strip them so the
+    # model dimension matches the data channels actually in use.
+    if :iad_hip ∉ table.kind
+        iad_keys = (:hip_iad_jitter, :iad_Δra, :iad_Δdec, :iad_Δplx,
+                    :iad_Δpmra, :iad_Δpmdec, :iad_pmra, :iad_pmdec)
+        priors = Priors(OrderedDict(k => v for (k, v) in priors.priors if k ∉ iad_keys))
+        derived = Derived(
+            OrderedDict(k => v for (k, v) in derived.variables if k ∉ iad_keys),
+            derived.captured_names, derived.captured_vals)
     end
     obj = G23HObs{
         typeof(table),
@@ -966,6 +986,34 @@ function ln_like(like::G23HObs, ctx::SystemObservationContext)
                 end
             end
 
+            # Change-of-variables Jacobian for the UEVA component (index 11).
+            # The MvNormal below treats t = UEVA_Gaia^(1/3) = μ_1_3 as the
+            # datum, but t is a parameter-dependent transform of the raw
+            # catalog datum:
+            #   :EAN  mode: t = (EAN² + σ_att² + σ_AL²)^(1/3),        datum EAN
+            #   :RUWE mode: t = (χ²_AL·(σ_att² + σ_AL²)/(N-dof))^(1/3), datum χ²_AL
+            #     (u0 cancels: (ruwe·u0)² = χ²_AL/(N-dof), and σ_formal² =
+            #      σ_att² + σ_AL² is parameter-dependent — see simulate!).
+            # A proper density in the raw datum needs log|dt/d(datum)|; the
+            # parameter-dependent parts (data-only constants omitted) are
+            #   :EAN : -(2/3)·log(UEVA_Gaia) = -2·log(μ_1_3)   [for EAN > 0]
+            #   :RUWE: +(1/3)·log(σ_att² + σ_AL²)
+            # Same class of bug as the rv_dr3 ξ² term (SBC 2026-07-04).
+            if mask[11]
+                if like.ueva_mode == :EAN
+                    # EAN == 0 is a boundary atom of the Gaia reduction (the
+                    # excess-noise fit pinned at zero); the continuous
+                    # change-of-variables does not apply there, so those stars
+                    # keep the untransformed density (flagged for a future
+                    # censored-likelihood treatment).
+                    if like.catalog.astrometric_excess_noise_dr3 > 0
+                        ll += -2 * log(μ_1_3)
+                    end
+                elseif like.ueva_mode == :RUWE
+                    ll += (T(1) / 3) * log(θ_obs.σ_att^2 + θ_obs.σ_AL^2)
+                end
+            end
+
             # We handle the iad separately from the big covariance matrix below, since it's not correlated
             # and we don't want to factorize a massively bigger matrix than necessary
             if :iad_hip ∈ like.table.kind
@@ -1040,7 +1088,15 @@ function ln_like(like::G23HObs, ctx::SystemObservationContext)
                     # Catalog's chi-squared statistic (Eq. A5)
                     ξ_catalog_squared = (N_rv - 1) * s_catalog_squared / σ_rv_per_transit^2
 
-                    ll += logpdf(rv_chi2_dist, ξ_catalog_squared)
+                    # Change-of-variables Jacobian: the raw datum is the catalog
+                    # radial_velocity_error ε, but the density above is evaluated
+                    # in ξ² = (N-1)·(2N/π)(ε² - 0.113²)/σ², a transform that
+                    # depends on the parameter σ_rv_per_transit. A proper density
+                    # in ε needs log|dξ²/dε| = log(2ε·(N-1)·2N/π) - 2·log(σ);
+                    # the data-only constant is omitted, the parameter-dependent
+                    # -2·log(σ) is required (without it the posterior is biased
+                    # high by 2·sd(ln σ)² in log space; caught by SBC 2026-07-04).
+                    ll += logpdf(rv_chi2_dist, ξ_catalog_squared) - 2 * log(σ_rv_per_transit)
                 catch
                     ll += -Inf
                 end
@@ -1452,6 +1508,10 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
         # IAD residual loop — identical to the slow path's loop but reading
         # Δα_mas_hip = Δδ_mas_hip ≡ 0 and σ_inflation_hip ≡ 1.
         if !isnothing(like.catalog.dist_hip)
+            # Only when the :iad_hip likelihood row is active: it is the sole
+            # consumer of iad_resid, and when it is excluded (epoch subset)
+            # the iad_* nuisance parameters are stripped from θ_obs entirely.
+            if :iad_hip ∈ like.table.kind
             (;iad_Δra, iad_Δdec, iad_pmra, iad_pmdec, iad_Δplx) = θ_obs
             plx_at_epoch = like.hip_sol.plx + iad_Δplx
             inv_julian_year = inv(julian_year)
@@ -1472,6 +1532,7 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
                 δ_off = iad_Δdec_eff + Δt * iad_pmdec_eff
                 proj_model = α_off * cosϕ + δ_off * sinϕ + plx_at_epoch * hip_plxFact[i_epoch]
                 iad_resid[i_epoch] = abs(hip_projMeas[i_epoch] - proj_model)
+            end
             end
             μ_h_fast = @SVector [θ_system.pmra + Δpmra_h, θ_system.pmdec + Δpmdec_h]
             hip_bias_pm_sq = Δpmra_h*Δpmra_h + Δpmdec_h*Δpmdec_h
@@ -1850,7 +1911,11 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
 
             Probably, one could put informed priors on most of these properies but we leave them wide open.
         =#
-        # if like.include_iad
+        # Only when the :iad_hip likelihood row is active: it is the sole
+        # consumer of iad_resid, and when it is excluded (epoch subset) the
+        # iad_* nuisance parameters are stripped from θ_obs entirely, so the
+        # destructure below would throw.
+        if :iad_hip ∈ like.table.kind
             (;iad_Δra,
                 iad_Δdec,
                 iad_pmra,
@@ -1909,7 +1974,7 @@ function simulate!(buffers, like::G23HObs, θ_system, θ_obs, orbits, orbit_solu
             # )
             # Main.stem(f[2,1], α✱_models, iad_resid)
             # f|>display
-        # end
+        end
 
     end
 
@@ -2427,8 +2492,13 @@ function Octofitter.generate_from_params(like::G23HObs, ctx::SystemObservationCo
         if add_noise
             # Inflate per-transit residual σ by the BINARYS first-harmonic factor
             # (Leclerc et al. 2023, Eq. 15) when generating synthetic noise.
+            # hip_iad_jitter only exists in θ_obs while the :iad_hip likelihood
+            # row is active (the nuisance block is stripped otherwise); without
+            # it, simulate the residual noise with zero excess jitter — the
+            # residuals are not consumed by any active likelihood term then.
+            hip_jitter = :iad_hip ∈ like.table.kind ? θ_obs.hip_iad_jitter : 0.0
             for i in 1:n_hip
-                new_hip_res[i] += randn() * hypot(like.hip_table.sres_renorm[i] * σ_inflation_hip[i], θ_obs.hip_iad_jitter)
+                new_hip_res[i] += randn() * hypot(like.hip_table.sres_renorm[i] * σ_inflation_hip[i], hip_jitter)
             end
         end
     end

--- a/src/likelihoods/g23h.jl
+++ b/src/likelihoods/g23h.jl
@@ -2428,7 +2428,7 @@ function Octofitter.generate_from_params(like::G23HObs, ctx::SystemObservationCo
             # Inflate per-transit residual σ by the BINARYS first-harmonic factor
             # (Leclerc et al. 2023, Eq. 15) when generating synthetic noise.
             for i in 1:n_hip
-                new_hip_res[i] += randn() * like.hip_table.sres_renorm[i] * σ_inflation_hip[i]
+                new_hip_res[i] += randn() * hypot(like.hip_table.sres_renorm[i] * σ_inflation_hip[i], θ_obs.hip_iad_jitter)
             end
         end
     end

--- a/src/likelihoods/gaia-utils.jl
+++ b/src/likelihoods/gaia-utils.jl
@@ -409,9 +409,37 @@ end
 # Sky path perturbation simulation
 # ──────────────────────────────────────────────────────────────────────
 
+# Hipparcos main grid step (Lindegren 1997, ESA SP-1200 vol 3). Used to set
+# `grid_step_arcsec` when calling `_simulate_skypath_perturbations!` for the
+# Hipparcos abscissa branch — triggers the BINARYS atan2 photocentre formula.
+const HIPPARCOS_GRID_STEP_ARCSEC = 1.2074
+
 """
-Given scan epochs and angles, and an orbit describing perturbations
-from a planet, calculate the astrometric perturbations to the sky path.
+Given scan epochs and angles, and an orbit describing perturbations from a
+(possibly luminous) companion, accumulate the astrometric perturbations to
+the sky path.
+
+When `grid_step_arcsec == 0.0` (default, used for Gaia), the perturbation
+follows the linear photocentre formula `(host + f·planet)/(1+f)`.
+
+When `grid_step_arcsec > 0.0` (Hipparcos: pass `HIPPARCOS_GRID_STEP_ARCSEC`),
+the perturbation follows the BINARYS along-scan formula (Leclerc et al. 2023,
+A&A 672 A82, Eq. 13):
+
+    Δν_B = (s/(2π)) · atan2(β sin ζ, 1 − β + β cos ζ) − B · ρ_p
+
+where ρ_p is the planet–host separation projected on the scan, ζ = 2π ρ_p/s,
+β = f/(1+f) is the secondary light fraction, B = M₂/(M₁+M₂) is the secondary
+mass fraction (carried implicitly via `raoff(sol, planet_mass_msol)`), and s is
+the grid step. The result is written along scan into (Δα, Δδ) such that the
+downstream projection b = Δα·cosϕ + Δδ·sinϕ recovers Δν_B exactly. The cross-
+scan components of (Δα, Δδ) are zeroed in this branch — the abscissa likelihood
+projects them out anyway.
+
+If `σ_inflation !== nothing`, the BINARYS branch additionally accumulates the
+multiplicative first-harmonic σ-inflation factor f_σ = (1+r)/√(1+2r cos ζ + r²)
+per transit (Leclerc et al. Eq. 15, with r = f). The caller passes a buffer
+initialised to 1 and multiplies the per-transit σ by it before the LSQ.
 """
 function _simulate_skypath_perturbations!(
     Δα_model, Δδ_model,
@@ -420,7 +448,18 @@ function _simulate_skypath_perturbations!(
     planet_mass_msol,
     flux_ratio,
     orbit_solutions, orbit_solutions_i_epoch_start, T=Float64;
+    grid_step_arcsec::Float64 = 0.0,
+    σ_inflation = nothing,
 )
+    if grid_step_arcsec > 0.0
+        return _simulate_skypath_perturbations_binarys!(
+            Δα_model, Δδ_model, σ_inflation,
+            table, orbit, planet_mass_msol, flux_ratio,
+            orbit_solutions, orbit_solutions_i_epoch_start, T,
+            grid_step_arcsec,
+        )
+    end
+
     for i in eachindex(table.epoch)
         if orbit_solutions_i_epoch_start >= 0
             sol = orbit_solutions[orbit_solutions_i_epoch_start+i]
@@ -439,6 +478,59 @@ function _simulate_skypath_perturbations!(
         dec_planet_vs_bary = dec_host_vs_bary + dec_planet_vs_host
         dec_photocentre = (dec_host_vs_bary + dec_planet_vs_bary * flux_ratio) / (1 + flux_ratio)
         Δδ_model[i] += dec_photocentre
+    end
+    return
+end
+
+function _simulate_skypath_perturbations_binarys!(
+    Δα_model, Δδ_model, σ_inflation,
+    table,
+    orbit::AbstractOrbit,
+    planet_mass_msol,
+    flux_ratio,
+    orbit_solutions, orbit_solutions_i_epoch_start, T,
+    s::Float64,
+)
+    β = flux_ratio / (1 + flux_ratio)
+    inv_2π_over_s = s / (2π)
+    for i in eachindex(table.epoch)
+        if orbit_solutions_i_epoch_start >= 0
+            sol = orbit_solutions[orbit_solutions_i_epoch_start+i]
+        else
+            sol = orbitsolve(orbit, table.epoch[i])
+        end
+
+        cosϕ = table.cosϕ[i]
+        sinϕ = table.sinϕ[i]
+
+        # Host reflex (encodes mass fraction B implicitly: host_along = −B·ρ_p)
+        ra_host_vs_bary  = raoff(sol, planet_mass_msol)
+        dec_host_vs_bary = decoff(sol, planet_mass_msol)
+        host_along = ra_host_vs_bary * cosϕ + dec_host_vs_bary * sinϕ
+
+        # Planet–host separation projected on scan
+        ra_planet_vs_host  = raoff(sol)
+        dec_planet_vs_host = decoff(sol)
+        ρ_p = ra_planet_vs_host * cosϕ + dec_planet_vs_host * sinϕ
+
+        ζ = 2π * ρ_p / s
+        sin_ζ, cos_ζ = sin(ζ), cos(ζ)
+        # BINARYS phase: atan2(β sin ζ, 1 − β + β cos ζ)
+        φ = atan(β * sin_ζ, 1 - β + β * cos_ζ)
+
+        # Δν_B = (s/(2π))·φ − B·ρ_p; host_along = −B·ρ_p, so:
+        Δν_B = inv_2π_over_s * φ + host_along
+
+        Δα_model[i] += Δν_B * cosϕ
+        Δδ_model[i] += Δν_B * sinϕ
+
+        if σ_inflation !== nothing
+            # Multiplicative σ inflation across companions: exact for ≤1 luminous
+            # companion (the dominant case); approximation for multiple luminous.
+            r = flux_ratio
+            f_σ = (1 + r) / sqrt(1 + 2 * r * cos_ζ + r^2)
+            σ_inflation[i] *= f_σ
+        end
     end
     return
 end

--- a/src/likelihoods/gaia-utils.jl
+++ b/src/likelihoods/gaia-utils.jl
@@ -357,37 +357,46 @@ function fit_5param_prepared(
 
     T = promote_type(eltype(Δα_mas), eltype(Δδ_mas))
 
-    # Use Bumper to elide allocations
+    # For a *scalar* weight the explicit σ_formal scaling is redundant: the
+    # LSQ x = (A/σ) \ (b/σ) is identical to x = A \ b — the σ cancels — so we
+    # solve unweighted and fold 1/σ² into the chi² at the end.  For a
+    # *per-epoch* σ vector (e.g. Hipparcos `sres`) the weights do NOT cancel
+    # and we perform the genuinely weighted solve.  Either way we solve
+    # against a Bumper-allocated copy of A_prepared (some `\` overloads
+    # require an owned matrix rather than a plain view).
     @no_escape begin
-        b_weighted = @alloc(T, n_obs)
-        A_weighted = @alloc(T, n_obs, size(A_prepared,2))
+        b = @alloc(T, n_obs)
+        A_dense = @alloc(T, n_obs, size(A_prepared, 2))
 
-        @. b_weighted = Δα_mas * table.cosϕ + Δδ_mas * table.sinϕ + residuals
-
-        if σ_formal != 0.
-            @. A_weighted = A_prepared .* 1 ./ σ_formal
-            @. b_weighted *= 1/σ_formal
+        @. b = Δα_mas * table.cosϕ + Δδ_mas * table.sinϕ + residuals
+        if σ_formal isa Number
+            @. A_dense = A_prepared
         else
-            @. A_weighted = A_prepared
+            @. A_dense = A_prepared / σ_formal
+            @. b = b / σ_formal
         end
 
-        x = A_weighted \ b_weighted
+        x = A_dense \ b
 
         parameters = @SVector [x[1], x[2], x[4], x[5], x[3]]
 
         if include_chi2 == Val(true)
-            model_predictions = @alloc(T, n_obs)
-            residuals = @alloc(T, n_obs)
-            mul!(model_predictions, A_weighted, x)
-            residuals .= b_weighted .- model_predictions
             if σ_formal == 0
                 error("Asked for `include_chi2=true` but `σ_formal==0`")
             end
+            model_predictions = @alloc(T, n_obs)
+            residuals_buf = @alloc(T, n_obs)
+            mul!(model_predictions, A_dense, x)
+            residuals_buf .= b .- model_predictions
 
-            chi_squared_astro = dot(residuals, residuals)
+            # Scalar σ: residuals are unweighted, apply 1/σ² here.
+            # Vector σ: residuals are already whitened by the weighted solve.
+            chi_squared_astro = σ_formal isa Number ?
+                dot(residuals_buf, residuals_buf) / (σ_formal * σ_formal) :
+                dot(residuals_buf, residuals_buf)
 
             n_parameters = 5
-            dof = length(b_weighted) - n_parameters
+            dof = n_obs - n_parameters
 
             chi2_reduced = chi_squared_astro / dof
         end
@@ -403,6 +412,26 @@ function fit_5param_prepared(
         dof
     )
 
+end
+
+"""
+    fit_5param_pinv(pinv_A, table, Δα_mas, Δδ_mas, residuals) -> nt
+
+Same as `fit_5param_prepared(...; include_chi2=Val(false))` but uses a
+pre-computed pseudo-inverse `pinv_A` (5×N) for the LSQ solve.  Returns
+just the SVector of parameters in the same order as fit_5param_prepared.
+"""
+function fit_5param_pinv(pinv_A, table, Δα_mas, Δδ_mas, residuals=0.0)
+    n_obs = size(pinv_A, 2)
+    T = promote_type(eltype(Δα_mas), eltype(Δδ_mas))
+    @no_escape begin
+        b = @alloc(T, n_obs)
+        @. b = Δα_mas * table.cosϕ + Δδ_mas * table.sinϕ + residuals
+        x_buf = @alloc(T, 5)
+        mul!(x_buf, pinv_A, b)
+        parameters = @SVector [x_buf[1], x_buf[2], x_buf[4], x_buf[5], x_buf[3]]
+    end
+    return (; parameters)
 end
 
 # ──────────────────────────────────────────────────────────────────────
@@ -446,24 +475,27 @@ function _simulate_skypath_perturbations!(
     flux_ratio,
     orbit_solutions, orbit_solutions_i_epoch_start, T=Float64,
 )
-    for i in eachindex(table.epoch)
-        if orbit_solutions_i_epoch_start >= 0
+    # The photocentre offset is `raoff(sol) · coeff` (and `decoff(sol) · coeff`)
+    # for the *same* `coeff` per call — derive it from the standard
+    # `(host_reflex + planet_bary · f) / (1 + f)` formula and hoist out of the
+    # loop. raoff(sol, m) = -m/M·raoff(sol) where M = totalmass(orbit). Use
+    # the `totalmass(orbit)` API so this works for Visual/AbsoluteVisual
+    # wrappers (no .M field) as well as bare KepOrbit.
+    M_tot = PlanetOrbits.totalmass(orbit)
+    m_host_eff = M_tot - planet_mass_msol
+    coeff = (-planet_mass_msol + flux_ratio * m_host_eff) / (M_tot * (1 + flux_ratio))
+    if orbit_solutions_i_epoch_start >= 0
+        @inbounds for i in eachindex(table.epoch)
             sol = orbit_solutions[orbit_solutions_i_epoch_start+i]
-        else
-            sol = orbitsolve(orbit, table.epoch[i])
+            Δα_model[i] += raoff(sol) * coeff
+            Δδ_model[i] += decoff(sol) * coeff
         end
-
-        # Add perturbation to photocentre from (possibly luminous) planet in mas
-        ra_host_vs_bary = raoff(sol, planet_mass_msol)
-        ra_planet_vs_host = raoff(sol)
-        ra_planet_vs_bary = ra_host_vs_bary + ra_planet_vs_host
-        ra_photocentre = (ra_host_vs_bary + ra_planet_vs_bary * flux_ratio) / (1 + flux_ratio)
-        Δα_model[i] += ra_photocentre
-        dec_host_vs_bary = decoff(sol, planet_mass_msol)
-        dec_planet_vs_host = decoff(sol)
-        dec_planet_vs_bary = dec_host_vs_bary + dec_planet_vs_host
-        dec_photocentre = (dec_host_vs_bary + dec_planet_vs_bary * flux_ratio) / (1 + flux_ratio)
-        Δδ_model[i] += dec_photocentre
+    else
+        @inbounds for i in eachindex(table.epoch)
+            sol = orbitsolve(orbit, table.epoch[i])
+            Δα_model[i] += raoff(sol) * coeff
+            Δδ_model[i] += decoff(sol) * coeff
+        end
     end
     return
 end
@@ -529,8 +561,28 @@ function _simulate_skypath_hippacentre_combined!(
     T,
     s::Float64,
 )
-    inv_2π_over_s = s / (2π)
     n_planets = length(orbits)
+    # Early-exit when no companion contributes (n_planets=0 has prior P=0.5,
+    # and any inactive companion has mass=0 from the @variables block).
+    # In that case the per-epoch loop reduces to: Re=1, Im=0, atan(0,1)=0,
+    # Δν_B=0 — so Δα/Δδ_model and σ_inflation are unchanged from their
+    # caller-initialised values (0 and 1 respectively).  Skip the
+    # transit loop entirely.
+    any_active = false
+    @inbounds for k in 1:n_planets
+        if planet_masses_msol[k] != zero(eltype(planet_masses_msol))
+            any_active = true
+            break
+        end
+    end
+    any_active || return
+
+    inv_2π_over_s = s / (2π)
+    two_π_over_s = (2π) / s
+    # Squared resolution scale in mas² — saves a sqrt per transit per active
+    # companion. α_resolve_hip(ρ) = exp(-(ρ/RES_arcsec)²) and ρ_arcsec =
+    # √(ra²+dec²)/1000, so (ρ_arcsec/RES_arcsec)² = (ra²+dec²)/(1000·RES_arcsec)².
+    inv_res_mas2 = 1 / (1000 * HIPPARCOS_RESOLUTION_ARCSEC)^2
     for i in eachindex(table.epoch)
         cosϕ = table.cosϕ[i]
         sinϕ = table.sinϕ[i]
@@ -544,6 +596,13 @@ function _simulate_skypath_hippacentre_combined!(
         host_along_total = zero(T)
 
         for k in 1:n_planets
+            # Absent companions (mass == 0 → host reflex 0; the calling site
+            # also forces flux_ratios[k] = 0 → modulated signal 0). Mirrors
+            # the DR2/DR3 _simulate_skypath_perturbations! short-circuit.
+            if planet_masses_msol[k] == zero(eltype(planet_masses_msol))
+                continue
+            end
+
             i_start_k = orbit_solutions_i_epoch_starts[k]
             sol_k = i_start_k >= 0 ?
                 orbit_solutions_per_planet[k][i_start_k + i] :
@@ -569,12 +628,12 @@ function _simulate_skypath_hippacentre_combined!(
             # limit (α → 0) Re → 1, Im → 0, φ → 0, f_σ → 1, so Δν_B reduces
             # to host_along_total exactly and no spurious σ inflation
             # remains.
-            ρ_full_arcsec = sqrt(ra_p*ra_p + dec_p*dec_p) / 1000  # mas → arcsec
-            α_k = α_resolve_hip(ρ_full_arcsec)
+            ρ_full_sq_mas2 = ra_p*ra_p + dec_p*dec_p
+            α_k = exp(-ρ_full_sq_mas2 * inv_res_mas2)
 
-            ζ_k = 2π * ρ_pk / s
+            ζ_k = two_π_over_s * ρ_pk
             f_k = flux_ratios[k] * α_k
-            sin_ζk, cos_ζk = sin(ζ_k), cos(ζ_k)
+            sin_ζk, cos_ζk = sincos(ζ_k)
             Re += f_k * cos_ζk
             Im += f_k * sin_ζk
             f_total += f_k

--- a/src/likelihoods/gaia-utils.jl
+++ b/src/likelihoods/gaia-utils.jl
@@ -414,6 +414,20 @@ end
 # abscissa branch.
 const HIPPARCOS_GRID_STEP_ARCSEC = 1.2074
 
+# Per-transit resolution gate for the BINARYS modulated photocentre.  At
+# projected separations ρ ≫ s, the Hipparcos pipeline either resolved the
+# components into separate Tycho/Hipparcos entries or rejected the row, so
+# the catalog point reflects the primary alone; the BINARYS atan2 modulation
+# must therefore taper to zero in this limit.  The atan2 formula does not do
+# this on its own — `(s/2π)·φ` keeps oscillating ±s/2 with separation.  We
+# gate the per-companion modulated-signal flux ratio by a Gaussian taper in
+# the *full* projected separation (not the along-scan projection ρ_pk, since
+# the resolution criterion is geometric, not abscissa-projected).  The
+# resolution scale is anchored to s = 1.207″ (Lindegren 1997 §3.3, ESA
+# SP-1200; van Leeuwen 2007 §6.4); refine empirically as needed.
+const HIPPARCOS_RESOLUTION_ARCSEC = 1.207
+α_resolve_hip(ρ_arcsec) = exp(-(ρ_arcsec / HIPPARCOS_RESOLUTION_ARCSEC)^2)
+
 """
 Given scan epochs and angles, and an orbit describing perturbations from a
 (possibly luminous) companion, accumulate the astrometric perturbations to
@@ -468,10 +482,11 @@ scan projection `b = Δα·cosϕ + Δδ·sinϕ` recovers Δν_B exactly. Cross-s
 components are zero (unobservable from a Hipparcos abscissa).
 
 For N companions (k = 1..N) at scan-projected separations ρ_p^(k) from the
-host, with Hp-band flux ratios f_k = L_k/L_host, the combined Hippacentre
-phase in the *host frame* is
+host, with Hp-band flux ratios f_k = L_k/L_host **gated by a per-transit
+resolution taper** α_k = α_resolve_hip(|ρ^(k)|), so that f_k_eff = f_k · α_k,
+the combined Hippacentre phase in the *host frame* is
 
-    φ = atan2( Σ_k f_k sin ζ_k ,  1 + Σ_k f_k cos ζ_k ),     ζ_k = 2π ρ_p^(k)/s
+    φ = atan2( Σ_k f_k_eff sin ζ_k ,  1 + Σ_k f_k_eff cos ζ_k ),     ζ_k = 2π ρ_p^(k)/s
 
 so the Hippacentre offset from the system barycentre, projected on scan, is
 
@@ -480,16 +495,22 @@ so the Hippacentre offset from the system barycentre, projected on scan, is
 where host_along^(k) is the host-vs-barycentre offset *due to companion k*
 projected on scan (encodes the per-companion mass fraction via
 `raoff(sol_k, m_k)`). Summing per-companion host-reflex contributions matches
-Octofitter's existing 2-body convention for `raoff(sol, m)`.
+Octofitter's existing 2-body convention for `raoff(sol, m)`.  The host-reflex
+sum is *not* gated by α — the host's barycentric motion is physical
+regardless of whether Hipparcos resolved the binary; only the modulated
+photocentre contribution tapers off in the resolved limit.
 
 The σ-inflation factor is the *combined* first-harmonic amplitude reduction
-(Leclerc et al. Eq. 15, generalised to N companions):
+(Leclerc et al. Eq. 15, generalised to N companions, using f_k_eff):
 
-    f_σ = (1 + Σ_k f_k) / sqrt( (1 + Σ_k f_k cos ζ_k)² + (Σ_k f_k sin ζ_k)² )
+    f_σ = (1 + Σ_k f_k_eff) / sqrt( (1 + Σ_k f_k_eff cos ζ_k)² + (Σ_k f_k_eff sin ζ_k)² )
 
 Pass `σ_inflation` as a buffer initialised to 1; it is multiplied in place by
 f_σ per transit. For all-dark companions (every f_k = 0) this routine reduces
 to Δν_B = Σ_k host_along^(k) and f_σ = 1, identical to the linear photocentre.
+For the wide-separation limit (every α_k → 0) it again reduces to
+Δν_B = Σ_k host_along^(k) and f_σ = 1 — the "resolved binary, primary alone"
+answer the Hipparcos pipeline would give.
 
 NOTE: The σ_inflation buffer is the noise-model correction for the *likelihood*
 comparison of the predicted abscissa to observed IAD residuals. It must NOT be
@@ -538,8 +559,21 @@ function _simulate_skypath_hippacentre_combined!(
             dec_p = decoff(sol_k)
             ρ_pk = ra_p * cosϕ + dec_p * sinϕ
 
+            # Per-transit resolution gate: the BINARYS modulated-signal
+            # contribution from companion k tapers to zero at ρ ≫ s, because
+            # at those separations the Hipparcos pipeline detected the pair
+            # as resolved (or rejected the row) and the catalog point is the
+            # primary alone.  Gate is applied to the modulated-signal f_k
+            # only — the host-reflex sum below is barycentric and remains
+            # physical regardless of resolution state.  In the resolved
+            # limit (α → 0) Re → 1, Im → 0, φ → 0, f_σ → 1, so Δν_B reduces
+            # to host_along_total exactly and no spurious σ inflation
+            # remains.
+            ρ_full_arcsec = sqrt(ra_p*ra_p + dec_p*dec_p) / 1000  # mas → arcsec
+            α_k = α_resolve_hip(ρ_full_arcsec)
+
             ζ_k = 2π * ρ_pk / s
-            f_k = flux_ratios[k]
+            f_k = flux_ratios[k] * α_k
             sin_ζk, cos_ζk = sin(ζ_k), cos(ζ_k)
             Re += f_k * cos_ζk
             Im += f_k * sin_ζk

--- a/src/likelihoods/gaia-utils.jl
+++ b/src/likelihoods/gaia-utils.jl
@@ -409,37 +409,20 @@ end
 # Sky path perturbation simulation
 # ──────────────────────────────────────────────────────────────────────
 
-# Hipparcos main grid step (Lindegren 1997, ESA SP-1200 vol 3). Used to set
-# `grid_step_arcsec` when calling `_simulate_skypath_perturbations!` for the
-# Hipparcos abscissa branch — triggers the BINARYS atan2 photocentre formula.
+# Hipparcos main grid step (Lindegren 1997, ESA SP-1200 vol 3). Used as the
+# argument `s` to `_simulate_skypath_hippacentre_combined!` for the Hipparcos
+# abscissa branch.
 const HIPPARCOS_GRID_STEP_ARCSEC = 1.2074
 
 """
 Given scan epochs and angles, and an orbit describing perturbations from a
 (possibly luminous) companion, accumulate the astrometric perturbations to
-the sky path.
+the sky path using the linear photocentre formula `(host + f·planet)/(1+f)`.
 
-When `grid_step_arcsec == 0.0` (default, used for Gaia), the perturbation
-follows the linear photocentre formula `(host + f·planet)/(1+f)`.
-
-When `grid_step_arcsec > 0.0` (Hipparcos: pass `HIPPARCOS_GRID_STEP_ARCSEC`),
-the perturbation follows the BINARYS along-scan formula (Leclerc et al. 2023,
-A&A 672 A82, Eq. 13):
-
-    Δν_B = (s/(2π)) · atan2(β sin ζ, 1 − β + β cos ζ) − B · ρ_p
-
-where ρ_p is the planet–host separation projected on the scan, ζ = 2π ρ_p/s,
-β = f/(1+f) is the secondary light fraction, B = M₂/(M₁+M₂) is the secondary
-mass fraction (carried implicitly via `raoff(sol, planet_mass_msol)`), and s is
-the grid step. The result is written along scan into (Δα, Δδ) such that the
-downstream projection b = Δα·cosϕ + Δδ·sinϕ recovers Δν_B exactly. The cross-
-scan components of (Δα, Δδ) are zeroed in this branch — the abscissa likelihood
-projects them out anyway.
-
-If `σ_inflation !== nothing`, the BINARYS branch additionally accumulates the
-multiplicative first-harmonic σ-inflation factor f_σ = (1+r)/√(1+2r cos ζ + r²)
-per transit (Leclerc et al. Eq. 15, with r = f). The caller passes a buffer
-initialised to 1 and multiplies the per-transit σ by it before the LSQ.
+This is the Gaia / small-separation form. For the Hipparcos abscissa branch
+(BINARYS atan2 Hippacentre) use `_simulate_skypath_hippacentre_combined!`
+instead — that routine must be called once with all companions because the
+modulated-signal Hippacentre is not the sum of per-companion Hippacentres.
 """
 function _simulate_skypath_perturbations!(
     Δα_model, Δδ_model,
@@ -447,19 +430,8 @@ function _simulate_skypath_perturbations!(
     orbit::AbstractOrbit,
     planet_mass_msol,
     flux_ratio,
-    orbit_solutions, orbit_solutions_i_epoch_start, T=Float64;
-    grid_step_arcsec::Float64 = 0.0,
-    σ_inflation = nothing,
+    orbit_solutions, orbit_solutions_i_epoch_start, T=Float64,
 )
-    if grid_step_arcsec > 0.0
-        return _simulate_skypath_perturbations_binarys!(
-            Δα_model, Δδ_model, σ_inflation,
-            table, orbit, planet_mass_msol, flux_ratio,
-            orbit_solutions, orbit_solutions_i_epoch_start, T,
-            grid_step_arcsec,
-        )
-    end
-
     for i in eachindex(table.epoch)
         if orbit_solutions_i_epoch_start >= 0
             sol = orbit_solutions[orbit_solutions_i_epoch_start+i]
@@ -482,54 +454,108 @@ function _simulate_skypath_perturbations!(
     return
 end
 
-function _simulate_skypath_perturbations_binarys!(
+"""
+    _simulate_skypath_hippacentre_combined!(
+        Δα_model, Δδ_model, σ_inflation,
+        table, orbits, planet_masses_msol, flux_ratios,
+        orbit_solutions_per_planet, orbit_solutions_i_epoch_starts, T, s,
+    )
+
+Compute the BINARYS Hippacentre along-scan offset Δν_B from the *combined*
+multi-companion modulated signal (Leclerc et al. 2023, A&A 672 A82, Eq. 13 +
+Eq. 15) and accumulate it into (Δα_model, Δδ_model) such that the downstream
+scan projection `b = Δα·cosϕ + Δδ·sinϕ` recovers Δν_B exactly. Cross-scan
+components are zero (unobservable from a Hipparcos abscissa).
+
+For N companions (k = 1..N) at scan-projected separations ρ_p^(k) from the
+host, with Hp-band flux ratios f_k = L_k/L_host, the combined Hippacentre
+phase in the *host frame* is
+
+    φ = atan2( Σ_k f_k sin ζ_k ,  1 + Σ_k f_k cos ζ_k ),     ζ_k = 2π ρ_p^(k)/s
+
+so the Hippacentre offset from the system barycentre, projected on scan, is
+
+    Δν_B = (s/2π) · φ + Σ_k host_along^(k)
+
+where host_along^(k) is the host-vs-barycentre offset *due to companion k*
+projected on scan (encodes the per-companion mass fraction via
+`raoff(sol_k, m_k)`). Summing per-companion host-reflex contributions matches
+Octofitter's existing 2-body convention for `raoff(sol, m)`.
+
+The σ-inflation factor is the *combined* first-harmonic amplitude reduction
+(Leclerc et al. Eq. 15, generalised to N companions):
+
+    f_σ = (1 + Σ_k f_k) / sqrt( (1 + Σ_k f_k cos ζ_k)² + (Σ_k f_k sin ζ_k)² )
+
+Pass `σ_inflation` as a buffer initialised to 1; it is multiplied in place by
+f_σ per transit. For all-dark companions (every f_k = 0) this routine reduces
+to Δν_B = Σ_k host_along^(k) and f_σ = 1, identical to the linear photocentre.
+
+NOTE: The σ_inflation buffer is the noise-model correction for the *likelihood*
+comparison of the predicted abscissa to observed IAD residuals. It must NOT be
+folded into the weighting of any LSQ that reproduces the published catalog
+5-parameter solution, because the catalog fit was performed by the Hipparcos
+pipeline with point-source σ.
+"""
+function _simulate_skypath_hippacentre_combined!(
     Δα_model, Δδ_model, σ_inflation,
     table,
-    orbit::AbstractOrbit,
-    planet_mass_msol,
-    flux_ratio,
-    orbit_solutions, orbit_solutions_i_epoch_start, T,
+    orbits,                          # iterable of <:AbstractOrbit
+    planet_masses_msol,              # iterable of mass (Msol)
+    flux_ratios,                     # iterable of Hp-band L_k/L_host
+    orbit_solutions_per_planet,      # iterable of orbit_solutions arrays
+    orbit_solutions_i_epoch_starts,  # iterable of Int
+    T,
     s::Float64,
 )
-    β = flux_ratio / (1 + flux_ratio)
     inv_2π_over_s = s / (2π)
+    n_planets = length(orbits)
     for i in eachindex(table.epoch)
-        if orbit_solutions_i_epoch_start >= 0
-            sol = orbit_solutions[orbit_solutions_i_epoch_start+i]
-        else
-            sol = orbitsolve(orbit, table.epoch[i])
-        end
-
         cosϕ = table.cosϕ[i]
         sinϕ = table.sinϕ[i]
 
-        # Host reflex (encodes mass fraction B implicitly: host_along = −B·ρ_p)
-        ra_host_vs_bary  = raoff(sol, planet_mass_msol)
-        dec_host_vs_bary = decoff(sol, planet_mass_msol)
-        host_along = ra_host_vs_bary * cosϕ + dec_host_vs_bary * sinϕ
+        # Combined modulated signal in the host frame:
+        #   1 (host, by convention) + Σ_k f_k · exp(i·ζ_k)
+        # Initial (Re, Im) is the host (k=0) contribution: 1 + 0i; f_total starts at 0.
+        Re = one(T)
+        Im = zero(T)
+        f_total = zero(T)
+        host_along_total = zero(T)
 
-        # Planet–host separation projected on scan
-        ra_planet_vs_host  = raoff(sol)
-        dec_planet_vs_host = decoff(sol)
-        ρ_p = ra_planet_vs_host * cosϕ + dec_planet_vs_host * sinϕ
+        for k in 1:n_planets
+            i_start_k = orbit_solutions_i_epoch_starts[k]
+            sol_k = i_start_k >= 0 ?
+                orbit_solutions_per_planet[k][i_start_k + i] :
+                orbitsolve(orbits[k], table.epoch[i])
 
-        ζ = 2π * ρ_p / s
-        sin_ζ, cos_ζ = sin(ζ), cos(ζ)
-        # BINARYS phase: atan2(β sin ζ, 1 − β + β cos ζ)
-        φ = atan(β * sin_ζ, 1 - β + β * cos_ζ)
+            # Host reflex from companion k (projected) = −B_k · ρ_p^(k)
+            ra_h  = raoff(sol_k, planet_masses_msol[k])
+            dec_h = decoff(sol_k, planet_masses_msol[k])
+            host_along_total += ra_h * cosϕ + dec_h * sinϕ
 
-        # Δν_B = (s/(2π))·φ − B·ρ_p; host_along = −B·ρ_p, so:
-        Δν_B = inv_2π_over_s * φ + host_along
+            # Companion-k separation from host, projected on scan
+            ra_p  = raoff(sol_k)
+            dec_p = decoff(sol_k)
+            ρ_pk = ra_p * cosϕ + dec_p * sinϕ
+
+            ζ_k = 2π * ρ_pk / s
+            f_k = flux_ratios[k]
+            sin_ζk, cos_ζk = sin(ζ_k), cos(ζ_k)
+            Re += f_k * cos_ζk
+            Im += f_k * sin_ζk
+            f_total += f_k
+        end
+
+        # Combined Hippacentre phase (host frame) and barycentre-frame offset
+        φ = atan(Im, Re)
+        Δν_B = inv_2π_over_s * φ + host_along_total
 
         Δα_model[i] += Δν_B * cosϕ
         Δδ_model[i] += Δν_B * sinϕ
 
         if σ_inflation !== nothing
-            # Multiplicative σ inflation across companions: exact for ≤1 luminous
-            # companion (the dominant case); approximation for multiple luminous.
-            r = flux_ratio
-            f_σ = (1 + r) / sqrt(1 + 2 * r * cos_ζ + r^2)
-            σ_inflation[i] *= f_σ
+            amp = sqrt(Re*Re + Im*Im)
+            σ_inflation[i] *= (1 + f_total) / amp
         end
     end
     return

--- a/src/likelihoods/gaia-utils.jl
+++ b/src/likelihoods/gaia-utils.jl
@@ -684,7 +684,7 @@ function GOST_forecast(ra_deg,dec_deg;baseline=:dr3)
         @info "Using provided Gaia scan forecast database $fname"
         forecast_table = CSV.read(fname, Table, normalizenames=true)
         themin, idx = findmin(hypot.(
-            (forecast_table.ra_rad_ .- deg2rad(ra_deg)) .*60 .*60 .*1000 .* cos(dec_deg),
+            (forecast_table.ra_rad_ .- deg2rad(ra_deg)) .*60 .*60 .*1000 .* cosd(dec_deg),
             (forecast_table.dec_rad_ .- deg2rad(dec_deg)).*60 .*60 .*1000
         ))
         if themin > 500
@@ -694,17 +694,17 @@ function GOST_forecast(ra_deg,dec_deg;baseline=:dr3)
         dec_rad = forecast_table.dec_rad_[idx]
         mask = isapprox.(forecast_table.ra_rad_, ra_rad) .& isapprox.(forecast_table.dec_rad_, dec_rad)
         @info "Found forecasted visibility windows" windows=count(mask)
-        if isempty(mask)
+        if !any(mask)
             error("Invalid condition: no visibility windows.")
         end
-        return forecast_table[mask,:]
+        return _sort_dedup_gost(forecast_table[mask,:])
     end
 
     fname = "GOST-$ra_deg-$dec_deg-$baseline.csv"
     if isfile(fname)
         @info "Using cached Gaia scan forecast $fname"
         forecast_table = CSV.read(fname, Table, normalizenames=true)
-        return forecast_table
+        return _sort_dedup_gost(forecast_table)
     end
 
     # Just pick a cookie ID to use.
@@ -761,7 +761,37 @@ function GOST_forecast(ra_deg,dec_deg;baseline=:dr3)
     end
     forecast_table = CSV.read(io, Table, normalizenames=true)
 
-    return forecast_table
+    return _sort_dedup_gost(forecast_table)
+end
+
+# Defensively sort and deduplicate a GOST forecast table.  User-supplied
+# catalogs have been observed to contain a target's entire forecast block
+# duplicated (even triplicated) verbatim, and everything downstream (window
+# slicing by findfirst/findlast, first/last epoch selection, missed-transit
+# accounting) assumes a time-sorted table of UNIQUE scans.  Real field-of-view
+# transits are ≥ 1.7 h apart (Gaia's 6 h spin, two FoVs), so rows closer than
+# ~10 s in time are duplicates of the same scan.
+function _sort_dedup_gost(tbl)
+    # vec(): table slices like `forecast_table[mask,:]` carry n×1 Matrix columns.
+    times = vec(collect(tbl.ObservationTimeAtBarycentre_BarycentricJulianDateInTCB_))
+    order = sortperm(times)
+    keep = Int[]
+    sizehint!(keep, length(order))
+    last_t = -Inf
+    for i in order
+        if times[i] - last_t > 1e-4  # days; ≈ 8.6 s
+            push!(keep, i)
+            last_t = times[i]
+        end
+    end
+    if length(keep) == length(times) && issorted(times)
+        return tbl  # already clean: return unchanged
+    end
+    @warn "GOST forecast contained duplicate and/or unsorted scan rows; sorted and deduplicated. Downstream results assume unique time-ordered scans." n_raw=length(times) n_unique=length(keep)
+    names = propertynames(tbl)
+    out = Table(NamedTuple{names}(map(p -> vec(getproperty(tbl, p))[keep], names)))
+    @assert issorted(vec(out.ObservationTimeAtBarycentre_BarycentricJulianDateInTCB_))
+    return out
 end
 
 

--- a/src/likelihoods/hipparcos.jl
+++ b/src/likelihoods/hipparcos.jl
@@ -570,36 +570,30 @@ function simulate(hiplike::HipparcosIADObs, θ_system, θ_obs, orbits, orbit_sol
         end
     end
 
-    # Pre-compute perturbations from all planets for all epochs using standardized function.
-    # The Hipparcos abscissa likelihood always uses the BINARYS atan2 photocentre formula
-    # and accumulates the per-transit first-harmonic σ inflation (Leclerc et al. 2023,
-    # A&A 672 A82, Eq. 13 + Eq. 15).
+    # Pre-compute perturbations from all planets for all epochs.
+    # The Hipparcos abscissa likelihood always uses the BINARYS atan2 photocentre
+    # formula; the multi-source modulated signal is computed jointly across all
+    # companions in a single pass (Leclerc et al. 2023, A&A 672 A82, Eq. 13 + Eq. 15).
     α✱_perturbations_total = zeros(T, length(hiplike.table.epoch))
     δ_perturbations_total = zeros(T, length(hiplike.table.epoch))
     σ_inflation_hip = ones(T, length(hiplike.table.epoch))
 
-    for planet_i in eachindex(orbits)
-        planet_mass_msol = θ_system.planets[planet_i].mass * Octofitter.mjup2msol
-        fluxratio_hip = θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip :
-                        θ_obs.fluxratio_hip[planet_i]
-
-        # Create temporary arrays for this planet's contribution
-        Δα_mas = zeros(T, length(hiplike.table.epoch))
-        Δδ_mas = zeros(T, length(hiplike.table.epoch))
-
-        _simulate_skypath_perturbations!(
-            Δα_mas, Δδ_mas,
-            hiplike.table, orbits[planet_i],
-            planet_mass_msol, fluxratio_hip,
-            orbit_solutions[planet_i], orbit_solutions_i_epoch_start[planet_i], T;
-            grid_step_arcsec = HIPPARCOS_GRID_STEP_ARCSEC,
-            σ_inflation = σ_inflation_hip,
-        )
-
-        # Add this planet's contribution to total perturbations
-        α✱_perturbations_total .+= Δα_mas
-        δ_perturbations_total .+= Δδ_mas
+    n_planets = length(orbits)
+    planet_masses_msol = ntuple(i -> θ_system.planets[i].mass * Octofitter.mjup2msol, n_planets)
+    flux_ratios_hip = ntuple(n_planets) do i
+        θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip : θ_obs.fluxratio_hip[i]
     end
+    # `orbit_solutions_i_epoch_start` is a scalar Int shared across planets;
+    # broadcast to a per-planet tuple for the combined Hippacentre routine.
+    orbit_sol_starts = ntuple(_ -> orbit_solutions_i_epoch_start, n_planets)
+
+    _simulate_skypath_hippacentre_combined!(
+        α✱_perturbations_total, δ_perturbations_total, σ_inflation_hip,
+        hiplike.table,
+        orbits, planet_masses_msol, flux_ratios_hip,
+        orbit_solutions, orbit_sol_starts, T,
+        HIPPARCOS_GRID_STEP_ARCSEC,
+    )
 
     for i in eachindex(hiplike.table.epoch)
 

--- a/src/likelihoods/hipparcos.jl
+++ b/src/likelihoods/hipparcos.jl
@@ -98,7 +98,7 @@ end
     HipparcosIADObs(;
         hip_id,
         variables=@variables begin
-            fluxratio ~ Product([Uniform(0, 1), Uniform(0, 1)])  # one entry for each companion
+            fluxratio_hip ~ Product([Uniform(0, 1), Uniform(0, 1)])  # one entry for each companion (Hp band)
         end
     )
 
@@ -106,8 +106,14 @@ Load the Hipparcos IAD observations.
 By default, this fetches and catches the extracted Java Tool edition of the
 van Leeuwan reduction.
 
-The `fluxratio` variable should be a Product distribution containing the flux ratio of each companion
-in the same order as the planets in the system.
+The Hipparcos abscissa likelihood applies the BINARYS atan2 photocentre formula
+and per-transit first-harmonic σ inflation (Leclerc et al. 2023, A&A 672 A82,
+Eq. 13 + Eq. 15).
+
+The `fluxratio_hip` variable is **required** and must be a Product distribution
+containing the Hp-band flux ratio of each companion in the same order as the
+planets in the system. (Note: distinct from `fluxratio`, which is the G-band
+ratio used by the Gaia DR2/DR3 photocentre branch in `G23HObs`.)
 
 Additional arguments:
 * `catalog`: path to the data directory. By default, will fetch from online and cache.
@@ -534,7 +540,9 @@ function ln_like(obs::HipparcosIADObs, ctx::PlanetObservationContext)
         if obs.table.reject[i]
             continue
         end
-        ll += logpdf(Normal(0, obs.table.sres_renorm[i]), hip_model.resid[i])
+        # σ inflated by BINARYS first-harmonic factor (Leclerc et al. 2023, Eq. 15).
+        ll += logpdf(Normal(0, obs.table.sres_renorm[i] * hip_model.σ_inflation[i]),
+                     hip_model.resid[i])
     end
 
     return ll
@@ -562,28 +570,32 @@ function simulate(hiplike::HipparcosIADObs, θ_system, θ_obs, orbits, orbit_sol
         end
     end
 
-    # Pre-compute perturbations from all planets for all epochs using standardized function
+    # Pre-compute perturbations from all planets for all epochs using standardized function.
+    # The Hipparcos abscissa likelihood always uses the BINARYS atan2 photocentre formula
+    # and accumulates the per-transit first-harmonic σ inflation (Leclerc et al. 2023,
+    # A&A 672 A82, Eq. 13 + Eq. 15).
     α✱_perturbations_total = zeros(T, length(hiplike.table.epoch))
     δ_perturbations_total = zeros(T, length(hiplike.table.epoch))
-    
+    σ_inflation_hip = ones(T, length(hiplike.table.epoch))
+
     for planet_i in eachindex(orbits)
         planet_mass_msol = θ_system.planets[planet_i].mass * Octofitter.mjup2msol
-        fluxratio = hasproperty(θ_obs, :fluxratio) ? θ_obs.fluxratio[planet_i] : zero(T)
-        
+        fluxratio_hip = θ_obs.fluxratio_hip isa Number ? θ_obs.fluxratio_hip :
+                        θ_obs.fluxratio_hip[planet_i]
+
         # Create temporary arrays for this planet's contribution
         Δα_mas = zeros(T, length(hiplike.table.epoch))
         Δδ_mas = zeros(T, length(hiplike.table.epoch))
-        
+
         _simulate_skypath_perturbations!(
             Δα_mas, Δδ_mas,
             hiplike.table, orbits[planet_i],
-            planet_mass_msol, fluxratio,
-            orbit_solutions[planet_i], orbit_solutions_i_epoch_start[planet_i], T
+            planet_mass_msol, fluxratio_hip,
+            orbit_solutions[planet_i], orbit_solutions_i_epoch_start[planet_i], T;
+            grid_step_arcsec = HIPPARCOS_GRID_STEP_ARCSEC,
+            σ_inflation = σ_inflation_hip,
         )
-        # TODO: I think _simulate_skypath_perturbations just accumulates in place-- 
-        # confirm if we really need these temporary variables and can't just pass
-        # in one set for multiple planet contributions
-        
+
         # Add this planet's contribution to total perturbations
         α✱_perturbations_total .+= Δα_mas
         δ_perturbations_total .+= Δδ_mas
@@ -690,7 +702,8 @@ function simulate(hiplike::HipparcosIADObs, θ_system, θ_obs, orbits, orbit_sol
     return (;
         α✱_model_with_perturbation=α✱_model_with_perturbation_out,
         δ_model_with_perturbation=δ_model_with_perturbation_out,
-        resid=resid_out
+        resid=resid_out,
+        σ_inflation=σ_inflation_hip,
     )
 end
 

--- a/src/likelihoods/hipparcos.jl
+++ b/src/likelihoods/hipparcos.jl
@@ -372,6 +372,13 @@ function HipparcosIADObs(;
         (table.x * cosd(α₀) * sind(δ₀) + table.y * sind(α₀) * sind(δ₀) - table.z * cosd(δ₀)) * table.sinϕ
     )
 
+    # Per-epoch scan-projected measured abscissa: hot path in g23h IAD
+    # residual loop reads this as a single column instead of recomputing
+    # `res + Δα✱·cosϕ + Δδ·sinϕ` (3 reads + 2 muls + 2 adds → 1 read).
+    # Identity follows from α✱ₐ = res·cosϕ + Δα✱, δₐ = res·sinϕ + Δδ, and
+    # cos²ϕ + sin²ϕ = 1.
+    table.proj_meas_alongscan = @. table.res + table.Δα✱ * table.cosϕ + table.Δδ * table.sinϕ
+
     table = Table(table)
 
     # Prepare some matrices for linear system solves

--- a/src/likelihoods/hipparcos.jl
+++ b/src/likelihoods/hipparcos.jl
@@ -569,10 +569,9 @@ function simulate(hiplike::HipparcosIADObs, θ_system, θ_obs, orbits, orbit_sol
         for i in eachindex(orbits)[2:end]
             if orbits[i].ra != orbit.ra ||
                orbits[i].dec != orbit.dec ||
-               orbits[i].pmra != orbit.rpma ||
-               orbits[i].pmdec != orbit.ra
-                pmdec
-                error("Planet orbits do not have matching ra, dec, pmpra, and pmdec.")
+               orbits[i].pmra != orbit.pmra ||
+               orbits[i].pmdec != orbit.pmdec
+                error("Planet orbits do not have matching ra, dec, pmra, and pmdec.")
             end
         end
     end

--- a/src/likelihoods/system.jl
+++ b/src/likelihoods/system.jl
@@ -1,6 +1,21 @@
 using Bumper
 
 
+"""
+    requires_solutions_for_zero_mass(likelihood) -> Bool
+
+Whether this likelihood may read per-planet orbit solutions for a planet
+whose sampled `mass` is exactly zero. Defaults to `true` (conservative).
+
+Likelihoods that internally short-circuit on `mass == 0` and never read a
+zero-mass planet's orbit solutions can override this to `false`. When every
+system-level likelihood returns `false` (and a planet has a `mass` variable
+and no planet-level likelihoods of its own), `make_ln_like` elides the
+per-epoch Kepler solves for that planet whenever its sampled mass is zero —
+a large win for multi-companion models with an `n_planets` prior that zeroes
+out absent companions.
+"""
+requires_solutions_for_zero_mass(::Any) = true
 
 
 function make_ln_like(system::System, θ_system)
@@ -112,9 +127,40 @@ function make_ln_like(system::System, θ_system)
             $key = $(OrbitType)(;merge(θ_system, θ_system.planets[$i])...)
         end
     
-        if isempty(all_epochs)  
+        # Skipping the per-epoch Kepler solves for an absent companion
+        # (sampled mass == 0) leaves $sols_key slots 2:end uninitialised, so
+        # it is only valid when nothing will ever read them. We decide this
+        # statically at codegen time: the planet must have a `mass` variable,
+        # must have no planet-level likelihoods of its own, and every
+        # system-level likelihood must declare via
+        # `requires_solutions_for_zero_mass` that it skips zero-mass
+        # companions internally (conservative default: it does not).
+        can_skip_zero_mass = hasproperty(θ_system.planets[i], :mass) &&
+            isempty(planet.observations) &&
+            all(!requires_solutions_for_zero_mass(obs) for obs in system.observations)
+        if isempty(all_epochs)
             orbit_sol_expr = quote
                 $sols_key = ()
+            end
+        elseif can_skip_zero_mass
+            orbit_sol_expr = quote
+                # Pre-solve kepler's equation for all epochs
+                epochs = @alloc(Float64, $(length(all_epochs)))
+                $((
+                    :(epochs[$j] = $(all_epochs[j]))
+                    for j in 1:length(all_epochs)
+                )...)
+
+                sol0 = orbitsolve($key, first(epochs))
+                $sols_key = @alloc(typeof(sol0), length(epochs))
+                $sols_key[begin] = sol0
+                # Skip per-epoch Kepler solves for absent companions (mass == 0).
+                # Verified safe at codegen time (see `can_skip_zero_mass` above):
+                # every consumer of these solutions short-circuits on mass == 0
+                # and never reads slots 2:end.
+                if θ_system.planets[$i].mass != zero(θ_system.planets[$i].mass)
+                    $_kepsolve_all!(view($sols_key, 2:length(epochs)), $key, view(epochs, 2:length(epochs)))
+                end
             end
         else
             orbit_sol_expr = quote
@@ -206,15 +252,20 @@ function make_ln_like(system::System, θ_system)
 end
 
 const _kepsolve_use_threads = Ref(false)
+# Threading is a net loss for short epoch loops: each Kepler solve costs
+# ~200 ns and `Threads.@threads` adds ~3–10 µs of orchestration. For small
+# N we always fall through to the single-thread path even when the user
+# has opted into threading.
+const _kepsolve_thread_min_n = 64
 function _kepsolve_all!(solutions, orbit, epochs)
-    if _kepsolve_use_threads[]
+    if _kepsolve_use_threads[] && length(epochs) >= _kepsolve_thread_min_n
         return _kepsolve_all_multithread!(solutions, orbit, epochs)
     else
         return _kepsolve_all_singlethread!(solutions, orbit, epochs)
     end
 end
 function _kepsolve_all_singlethread!(solutions, orbit, epochs)
-    for epoch_i in eachindex(epochs)
+    @inbounds for epoch_i in eachindex(epochs)
         solutions[epoch_i] = orbitsolve(orbit, epochs[epoch_i])
     end
     return solutions


### PR DESCRIPTION
Performance improvements to the G23H likelihood, and major bug fix

G23H window & correlation (found via injection-recovery false positives):
- Sort partialsortperm-selected transit subsets chronologically (3 sites);
  priority-ordered indices collapsed the DR2/DR3 window slices, inflating
  the DR2-DR3 PM correlation to ~0.98 (true median ~0.80)
- Trim GOST forecast table to the DR3 window at construction
- generate_from_params: draw DR2/DR32/DR3 PMs from the same correlated
  covariance ln_like assembles (K = rho sqrt(Sigma2) sqrt(Sigma3)', truth
  deflation, Delta-Sigma_dr32), and mirror the HGCA nonlinear PM correction

Audit fixes (2026-07-02):
- GOST_forecast: sort + deduplicate forecast rows on every return path and
  assert time-sortedness (a user-supplied catalog contained duplicated
  per-target scan blocks for 1,412 of 108,643 targets); fix cos(dec) taken
  in degrees in the catalog-match metric (cosd); fix dead isempty(mask)
  guard (!any)
- Recompute Hipparcos res-derived columns (proj_meas_alongscan etc.) after
  the in-place +0.140 mas Brandt et al. recalibration, which previously
  never reached the IAD channel
- Exclude Hipparcos-rejected scans (sres <= 0) from the catalog-
  reproduction weighted LSQ (Q_hip)
- Fix HipparcosIADObs multi-planet simulate consistency check (orbit.rpma
  typo, pmdec-vs-ra comparison, stray statement) which made any >=2-planet
  use throw
