### PR TITLE
Handle non-finite orbital parameters in skypath simulation

### DIFF
--- a/src/likelihoods/gaia-utils.jl
+++ b/src/likelihoods/gaia-utils.jl
@@ -633,7 +633,19 @@ function _simulate_skypath_hippacentre_combined!(
 
             ζ_k = two_π_over_s * ρ_pk
             f_k = flux_ratios[k] * α_k
-            sin_ζk, cos_ζk = sincos(ζ_k)
+            # A degenerate orbit proposal (e.g. an extreme sampler step) can
+            # make raoff/decoff — and hence ρ_pk and ζ_k — non-finite. Julia's
+            # `sincos` throws a DomainError on ±Inf/NaN, which would crash the
+            # whole evaluation. The host-reflex term below is already ±Inf for
+            # such a proposal, so the model is non-finite regardless; propagate
+            # NaN here instead of throwing so the sample is cleanly rejected
+            # (−Inf log-likelihood), mirroring the DR2/DR3 skypath path which
+            # never calls trig and just lets Inf flow downstream.
+            if isfinite(ζ_k)
+                sin_ζk, cos_ζk = sincos(ζ_k)
+            else
+                sin_ζk = cos_ζk = oftype(ζ_k, NaN)
+            end
             Re += f_k * cos_ζk
             Im += f_k * sin_ζk
             f_total += f_k


### PR DESCRIPTION
## Summary
Added defensive handling for non-finite orbital parameters in the `_simulate_skypath_hippacentre_combined!` function to prevent crashes during degenerate orbit proposals.

## Key Changes
- Added a finiteness check before calling `sincos(ζ_k)` to handle cases where orbital parameters become non-finite (±Inf/NaN)
- When `ζ_k` is non-finite, `sin_ζk` and `cos_ζk` are set to NaN instead of throwing a DomainError
- This allows the model to propagate NaN values downstream, resulting in a −Inf log-likelihood that cleanly rejects the sample

## Implementation Details
- The check uses `isfinite(ζ_k)` to detect problematic values that would cause `sincos()` to throw
- Non-finite values are replaced with NaN using `oftype(ζ_k, NaN)` to preserve the original type
- This approach mirrors the behavior of the DR2/DR3 skypath implementation, which avoids calling trigonometric functions and lets Inf values flow naturally through the computation
- Degenerate orbit proposals (e.g., extreme sampler steps) that cause non-finite raoff/decoff values are now handled gracefully rather than crashing the evaluation

https://claude.ai/code/session_01M5tasKD4q1zwETnpUU8AyG